### PR TITLE
Allow for creation of acls and http_access from class creation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ log/
 .idea/
 *.iml
 .*.sw
+.*swp

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `coredump_dir` defaults to undef. [coredump_dir docs](http://www.squid-cache.org/Doc/config/coredump_dir/).
 * `max_filedescriptors` defaults to undef. [max_filedescriptors docs](http://www.squid-cache.org/Doc/config/max_filedescriptors/).
 * `workers` defaults to undef. [workers docs](http://www.squid-cache.org/Doc/config/workers/).
+* `acls` defaults to undef. If you pass in a hash of acl entries, they will be defined automatically. [acl entries](http://www.squid-cache.org/Doc/config/acl/).
+* `http_access` defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. [http_access entries](http://www.squid-cache.org/Doc/config/http_access/).
 
 ```puppet
 class{'::squid':
@@ -49,6 +51,23 @@ class{'::squid':
   coredump_dir = '/var/spool/squid',
 }
 ```
+
+```puppet
+class{'::squid':
+  cache_mem    = '512 MB',
+  workers      = 3,
+  coredump_dir = '/var/spool/squid',
+  acls         = { 'remote_urls' => {
+                       type    => 'url_regex',
+                       entries => ['http://example.org/path',
+                                   'http://example.com/anotherpath'],
+                       },
+                 },
+  http_access  = { 'our_networks hosts' =>  { action => 'allow', },
+}
+```
+
+The acls and http_access lines above are equivalent to their examples below.
 
 ### Defined Type squid::acl
 Defines [acl entries](http://www.squid-cache.org/Doc/config/acl/) for a squid server.
@@ -68,6 +87,8 @@ would result in a multi entry squid acl
 acl remote_urls url_regex http://example.org/path
 acl remote_urls url_regex http://example.com/anotherpath
 ```
+
+These may be defined as a hash passed to ::squid
 
 #### Parameters for  Type squid::acl
 * `type` The acltype of the acl, must be defined, e.g url_regex, urlpath_regex, port, ..
@@ -120,9 +141,11 @@ Adds a squid.conf line
 http_access allow our_networks hosts
 ```
 
+These may be defined as a hash passed to ::squid
+
 #### Parameters for Type squid::http\_allow
 * `value` defaults to the `namevar` the rule to allow or deny.
-* `action` must be `deny` or `allow`. By default it is allow. The squid.conf file is order so by default
+* `action` must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
    all allows appear before all denys. This can be overidden with the `order` parameter.
 * `order` by default is `05`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,8 @@ class squid::config (
   $coredump_dir                  = $squid::coredump_dir,
   $max_filedescriptors           = $squid::max_filedescriptors,
   $workers                       = $squid::workers,
+  $acls                          = $squid::acls,
+  $http_access                   = $squid::http_access,
 ) inherits squid {
 
   concat{$config:
@@ -20,5 +22,12 @@ class squid::config (
     target  => $config,
     content => template('squid/squid.conf.header.erb'),
     order   => '01',
+  }
+
+  if $acls {
+    create_resources('squid::acl', $acls)
+  }
+  if $http_access {
+    create_resources('squid::http_access', $http_access)
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,8 @@ class squid (
   $coredump_dir                  = $squid::params::coredump_dir,
   $max_filedescriptors           = $squid::params::max_filedescriptors,
   $workers                       = $squid::params::workers,
+  $acls                          = $squid::params::acls,
+  $http_access                   = $squid::params::http_access,
 ) inherits ::squid::params {
 
   validate_re($cache_mem,'\d+ MB')
@@ -26,11 +28,19 @@ class squid (
     validate_integer($workers)
   }
 
+  if $acls {
+    validate_hash($acls)
+  }
+  if $http_access {
+    validate_hash($http_access)
+  }
 
   anchor{'squid::begin':} ->
   class{'::squid::install':} ->
   class{'::squid::config':} ~>
   class{'::squid::service':} ->
   anchor{'squid::end':}
+
+
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,4 +8,6 @@ class squid::params {
   $coredump_dir                  = undef
   $max_filedescriptors           = undef
   $workers                       = undef
+  $acls                          = undef
+  $http_access                   = undef
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -37,4 +37,83 @@ describe 'squid' do
     it { should contain_concat_fragment('squid_header').with_content(/^max_filedescriptors\s+1000$/) }
     it { should contain_concat_fragment('squid_header').with_content(/^workers\s+8$/) }
   end
+
+  context 'with one acl parameter set' do
+    let :params do
+      { config: '/tmp/squid.conf',
+        acls: { 'myacl' => { 'type' => 'urlregex',
+                             'order' => '07',
+                             'entries' => ['http://example.org/', 'http://example.com/'],
+                           },
+              },
+      }
+    end
+    it { should contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+    it { should contain_concat_fragment('squid_acl_myacl').with_order('10-07-urlregex') }
+    it { should contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.org/$}) }
+    it { should contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.com/$}) }
+  end
+
+  context 'with two acl parameters set' do
+    let :params do
+      { config: '/tmp/squid.conf',
+        acls: { 'myacl' => { 'type' => 'urlregex',
+                             'order' => '07',
+                             'entries' => ['http://example.org/', 'http://example.com/'],
+                           },
+                'mysecondacl' => { 'type' => 'urlregex',
+                                   'order' => '08',
+                                   'entries' => ['http://example2.org/', 'http://example2.com/'],
+                                 },
+              },
+      }
+    end
+    it { should contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+    it { should contain_concat_fragment('squid_acl_myacl').with_order('10-07-urlregex') }
+    it { should contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.org/$}) }
+    it { should contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.com/$}) }
+    it { should contain_concat_fragment('squid_acl_mysecondacl').with_order('10-08-urlregex') }
+    it { should contain_concat_fragment('squid_acl_mysecondacl').with_content(%r{^acl\s+mysecondacl\s+urlregex\shttp://example2.org/$}) }
+    it { should contain_concat_fragment('squid_acl_mysecondacl').with_content(%r{^acl\s+mysecondacl\s+urlregex\shttp://example2.com/$}) }
+  end
+
+  context 'with one http_access parameter set' do
+    let :params do
+      { config: '/tmp/squid.conf',
+        http_access: { 'myrule' => { 'action' => 'deny',
+                                     'value' => 'this and that',
+                                     'order' => '08',
+                                   },
+                     },
+      }
+    end
+    it { should contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+    it { should contain_concat_fragment('squid_http_access_this and that').with_target('/tmp/squid.conf') }
+    it { should contain_concat_fragment('squid_http_access_this and that').with_order('20-08-deny') }
+    it { should contain_concat_fragment('squid_http_access_this and that').with_content(/^http_access\s+deny\s+this and that$/) }
+  end
+
+  context 'with two http_access parameters set' do
+    let :params do
+      { config: '/tmp/squid.conf',
+        http_access: { 'myrule' => { 'action' => 'deny',
+                                     'value'  => 'this and that',
+                                     'order'  => '08',
+                                  },
+                       'secondrule' => { 'action' => 'deny',
+                                         'value'  => 'this too',
+                                         'order'  => '09',
+                                       },
+                     },
+
+      }
+    end
+    it { should contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+    it { should contain_concat_fragment('squid_http_access_this and that').with_target('/tmp/squid.conf') }
+    it { should contain_concat_fragment('squid_http_access_this and that').with_order('20-08-deny') }
+    it { should contain_concat_fragment('squid_http_access_this and that').with_content(/^http_access\s+deny\s+this and that$/) }
+    it { should contain_concat_fragment('squid_http_access_this too').with_target('/tmp/squid.conf') }
+    it { should contain_concat_fragment('squid_http_access_this too').with_order('20-09-deny') }
+    it { should contain_concat_fragment('squid_http_access_this too').with_content(/^http_access\s+deny\s+this too$/) }
+  end
 end


### PR DESCRIPTION
Allow for creation of acls and http_access from class creation for hiera/ENC.  This should prevent the need to create a custom class to setup basic ACLs.  It should play nice with heira and ENC providers.
