### PR TITLE
Add config_user, config_group and service_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `ensure_service` The ensure value of the squid service, defaults to `running`.
 * `enable_service` The enable value of the squid service, defaults to `true`.
 * `config` Location of squid.conf file, defaults to `/etc/squid/squid.conf`.
+* `config_user` user which owns the config file, defaults to `root`.
+* `config_group` group which owns the config file, defaults to `squid`.
 * `cache_mem` defaults to `256 MB`. [cache_mem docs](http://www.squid-cache.org/Doc/config/cache_mem/).
 * `memory_cache_shared` defaults to undef. [memory_cache_shared docs](http://www.squid-cache.org/Doc/config/memory_cache_shared/).
 * `maximum_object_size_in_memory` defaults to `512 KB`. [maximum_object_size_in_memory docs](http://www.squid-cache.org/Doc/config/maximum_object_size_in_memory/)
@@ -46,6 +48,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `acls` defaults to undef. If you pass in a hash of acl entries, they will be defined automatically. [acl entries](http://www.squid-cache.org/Doc/config/acl/).
 * `http_access` defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. [http_access entries](http://www.squid-cache.org/Doc/config/http_access/).
 * `http_ports` defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. [http_port entries](http://www.squid-cache.org/Doc/config/http_port/).
+* `service_name` name of the squid service to manage, defaults to `squid`.
 * `snmp_ports` defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. [snmp_port entries](http://www.squid-cache.org/Doc/config/snmp_port/).
 * `cache_dirs` defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. [cache_dir entries](http://www.squid-cache.org/Doc/config/cache_dir/).
 

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -14,7 +14,7 @@ define squid::auth_param (
   concat::fragment{"squid_auth_param_${auth_param_name}":
     target  => $::squid::config,
     content => template('squid/squid.conf.auth_param.erb'),
-    order   => "40-${order}-${scheme}",
+    order   => "05-${order}-${scheme}",
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,7 @@
 class squid::config (
   $config                        = $squid::config,
+  $config_user                   = $squid::config_user,
+  $config_group                  = $squid::config_group,
   $cache_mem                     = $squid::cache_mem,
   $memory_cache_shared           = $squid::memory_cache_shared,
   $maximum_object_size_in_memory = $squid::maximum_object_size_in_memory,
@@ -17,8 +19,8 @@ class squid::config (
 
   concat{$config:
     ensure => present,
-    owner  => root,
-    group  => squid,
+    owner  => $config_user,
+    group  => $config_group,
     mode   => '0640',
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,8 @@ class squid (
   $ensure_service                = $squid::params::ensure_service,
   $enable_service                = $squid::params::enable_service,
   $config                        = $squid::params::config,
+  $config_user                   = $squid::params::config_user,
+  $config_group                  = $squid::params::config_group,
   $cache_mem                     = $squid::params::cache_mem,
   $memory_cache_shared           = $squid::params::memory_cache_shared,
   $maximum_object_size_in_memory = $squid::params::maximum_object_size_in_memory,
@@ -13,6 +15,7 @@ class squid (
   $http_access                   = $squid::params::http_access,
   $auth_params                   = $squid::params::auth_params,
   $http_ports                    = $squid::params::http_ports,
+  $service_name                  = $squid::params::service_name,
   $snmp_ports                    = $squid::params::snmp_ports,
   $cache_dirs                    = $squid::params::cache_dirs,
 ) inherits ::squid::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,8 @@ class squid::params {
   $ensure_service                = 'running'
   $enable_service                = true
   $config                        = '/etc/squid/squid.conf'
+  $config_user                   = 'root'
+  $config_group                  = 'squid'
   $cache_mem                     = '256 MB'
   $memory_cache_shared           = undef
   $maximum_object_size_in_memory = '512 KB'
@@ -14,6 +16,7 @@ class squid::params {
   $http_access                   = undef
   $auth_params                   = undef
   $http_ports                    = undef
+  $service_name                  = 'squid'
   $snmp_ports                    = undef
   $cache_dirs                    = undef
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,6 @@
 class squid::service inherits squid {
 
-  service{'squid':
+  service{$squid::service_name:
     ensure => $squid::ensure_service,
     enable => $squid::enable_service,
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,21 +22,27 @@ describe 'squid' do
     let :params do
       {
         config: '/tmp/squid.conf',
+        config_user: 'nobody',
+        config_group: 'nobody',
         cache_mem: '1024 MB',
         memory_cache_shared: 'on',
         access_log: '/var/log/out.log',
         coredump_dir: '/tmp/core',
+        service_name: 'squid3',
         max_filedescriptors: 1000,
         workers: 8
       }
     end
     it { should contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+    it { should contain_concat('/tmp/squid.conf').with_owner('nobody') }
+    it { should contain_concat('/tmp/squid.conf').with_group('nobody') }
     it { should contain_concat_fragment('squid_header').with_content(%r{^cache_mem\s+1024 MB$}) }
     it { should contain_concat_fragment('squid_header').with_content(%r{^memory_cache_shared\s+on$}) }
     it { should contain_concat_fragment('squid_header').with_content(%r{^access_log\s+/var/log/out.log$}) }
     it { should contain_concat_fragment('squid_header').with_content(%r{^coredump_dir\s+/tmp/core$}) }
     it { should contain_concat_fragment('squid_header').with_content(%r{^max_filedescriptors\s+1000$}) }
     it { should contain_concat_fragment('squid_header').with_content(%r{^workers\s+8$}) }
+    it { should contain_service('squid3').with_ensure('running') }
   end
 
   context 'with one acl parameter set' do

--- a/spec/defines/auth_param_spec.rb
+++ b/spec/defines/auth_param_spec.rb
@@ -22,7 +22,7 @@ describe 'squid::auth_param' do
       }
     end
     it { should contain_concat__fragment('squid_auth_param_auth').with_target('/tmp/squid.conf') }
-    it { should contain_concat__fragment('squid_auth_param_auth').with_order('40-07-basic') }
+    it { should contain_concat__fragment('squid_auth_param_auth').with_order('05-07-basic') }
     entries.each do |entry|
       it { should contain_concat__fragment('squid_auth_param_auth').with_content(%r{auth_param basic #{entry}}) }
     end


### PR DESCRIPTION
* Allow specifying the user/group that own `squid.conf`
  * Ubuntu runs the squid service as the `proxy` user/group, so this allows using the module on Ubuntu with minor changes
* Allow specifying the service_name
  * Ubuntu names the service `squid3`
* Rearrange auth_params to come before acls
  * The `auth_param` needs to come before `acl` in the configuration file;
otherwise, squid will throw `ERROR: Invalid ACL`
* Accompanying documentation and spec updates to support the above changes.