### PR TITLE
Rearrange auth_params to come before acls

### DIFF
--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -14,7 +14,7 @@ define squid::auth_param (
   concat::fragment{"squid_auth_param_${auth_param_name}":
     target  => $::squid::config,
     content => template('squid/squid.conf.auth_param.erb'),
-    order   => "40-${order}-${scheme}",
+    order   => "05-${order}-${scheme}",
   }
 
 }

--- a/spec/defines/auth_param_spec.rb
+++ b/spec/defines/auth_param_spec.rb
@@ -27,7 +27,7 @@ describe 'squid::auth_param' do
           }
         end
         it { should contain_concat__fragment('squid_auth_param_auth').with_target('/tmp/squid.conf') }
-        it { should contain_concat__fragment('squid_auth_param_auth').with_order('40-07-basic') }
+        it { should contain_concat__fragment('squid_auth_param_auth').with_order('05-07-basic') }
         entries.each do |entry|
           it { should contain_concat__fragment('squid_auth_param_auth').with_content(%r{auth_param basic #{entry}}) }
         end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

The `auth_param` needs to come before `acl` in the configuration file;
otherwise, squid will throw `ERROR: Invalid ACL`