### PR TITLE
adds logformat directive to squid.conf header

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class squid (
   $cache_mem                     = $squid::params::cache_mem,
   $memory_cache_shared           = $squid::params::memory_cache_shared,
   $maximum_object_size_in_memory = $squid::params::maximum_object_size_in_memory,
+  $logformat                     = $squid::params::logformat,
   $access_log                    = $squid::params::access_log,
   $coredump_dir                  = $squid::params::coredump_dir,
   $max_filedescriptors           = $squid::params::max_filedescriptors,
@@ -37,6 +38,7 @@ class squid (
     validate_re($memory_cache_shared,['^on$','^off$'])
   }
   validate_re($maximum_object_size_in_memory,'\d+ KB')
+  validate_string($logformat)
   validate_string($access_log)
   if $coredump_dir {
     validate_string($coredump_dir)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class squid::params {
   $https_ports                   = undef
   $snmp_ports                    = undef
   $cache_dirs                    = undef
+  $logformat                     = undef
 
   case $::operatingsystem {
     /^(Debian|Ubuntu)$/: {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,6 +57,7 @@ describe 'squid' do
             config: '/tmp/squid.conf',
             cache_mem: '1024 MB',
             memory_cache_shared: 'on',
+            logformat: 'squid %tl.%03tu %6tr %>a %Ss/%03Hs',
             access_log: '/var/log/out.log',
             coredump_dir: '/tmp/core',
             max_filedescriptors: 1000,
@@ -66,6 +67,7 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^cache_mem\s+1024 MB$}) }
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^memory_cache_shared\s+on$}) }
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^logformat\s+squid %tl.%03tu %6tr %>a %Ss/%03Hs$}) }
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^access_log\s+/var/log/out.log$}) }
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^coredump_dir\s+/tmp/core$}) }
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^max_filedescriptors\s+1000$}) }

--- a/templates/squid.conf.header.erb
+++ b/templates/squid.conf.header.erb
@@ -10,6 +10,9 @@ memory_cache_shared           <%= @memory_cache_shared %>
 <% end -%>
 maximum_object_size_in_memory <%= @maximum_object_size_in_memory %>
 
+<% if @logformat -%>
+logformat                     <%= @logformat %>
+<% end -%>
 access_log                    <%= @access_log %>
 
 <% if @coredump_dir -%>


### PR DESCRIPTION
The `logformat` directive in squid.conf has to be defined before the `access_log` directive in order to take effect.  This PR just adds a logformat param to squid and adds it to the squid.conf header if it is provided.
