### PR TITLE
Added ssl_bump and sslproxy_cert_error support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `https_ports` defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. [https_port entries](http://www.squid-cache.org/Doc/config/https_port/).
 * `snmp_ports` defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. [snmp_port entries](http://www.squid-cache.org/Doc/config/snmp_port/).
 * `cache_dirs` defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. [cache_dir entries](http://www.squid-cache.org/Doc/config/cache_dir/).
+* `ssl_bump` defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. [ssl_bump entries](http://www.squid-cache.org/Doc/config/ssl_bump/).
+* `sslproxy_cert_error` defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. [sslproxy_cert_error entries](http://www.squid-cache.org/Doc/config/sslproxy_cert_error/).
 * `extra_config_sections` defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
 
 ```puppet
@@ -250,6 +252,51 @@ These may be defined as a hash passed to ::squid
 * `scheme` the scheme used for authentication must be defined
 * `entries` An array of entries, multiple members results in multiple lines in squid.conf
 * `order` by default is '40'
+
+### Defined Type squid::ssl\_bump
+Defines [ssl_bump entries](http://www.squid-cache.org/Doc/config/ssl_bump/) for a squid server.
+
+```puppet
+squid::ssl_bump{'all':
+  action => 'bump',
+}
+```
+
+Adds a squid.conf line 
+
+```
+ssl_bump bump all
+```
+
+These may be defined as a hash passed to ::squid
+
+#### Parameters for Type squid::ssl\_bump
+* `value` The type of the ssl_bump, must be defined, e.g bump, peek, ..
+* `action` The name of acl, defaults to `bump`.
+* `order` by default is `05`
+
+### Defined Type squid::sslproxy\_cert\_error
+Defines [sslproxy_cert_error entries](http://www.squid-cache.org/Doc/config/sslproxy_cert_error/) for a squid server.
+
+```puppet
+squid::sslproxy_cert_error{'all':
+  action => 'allow',
+}
+```
+
+Adds a squid.conf line 
+
+```
+sslproxy_cert_error allow all
+```
+
+These may be defined as a hash passed to ::squid
+
+#### Parameters for Type squid::sslproxy\_cert\_error
+* `value` defaults to the `namevar` the rule to allow or deny.
+* `action` must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
+   all allows appear before all denys. This can be overidden with the `order` parameter.
+* `order` by default is `05`
 
 ### Defined Type squid::extra\_config\_section
 Squid has a large number of configuration directives.  Not all of these have been exposed individually in this module.  For those that haven't, the `extra_config_section` defined type can be used.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,8 @@ class squid::config (
   $http_ports                    = $::squid::http_ports,
   $https_ports                   = $::squid::https_ports,
   $snmp_ports                    = $::squid::snmp_ports,
+  $ssl_bump                      = $::squid::ssl_bump,
+  $sslproxy_cert_error           = $::squid::sslproxy_cert_error,
   $cache_dirs                    = $::squid::cache_dirs,
   $extra_config_sections         = $::squid::extra_config_sections,
 ) inherits squid {
@@ -52,6 +54,12 @@ class squid::config (
   }
   if $cache_dirs {
     create_resources('squid::cache_dir', $cache_dirs)
+  }
+  if $ssl_bump {
+    create_resources('squid::ssl_bump', $ssl_bump)
+  }
+  if $sslproxy_cert_error {
+    create_resources('squid::sslproxy_cert_error', $sslproxy_cert_error)
   }
   create_resources('squid::extra_config_section', $extra_config_sections)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,8 @@ class squid (
   $cache_dirs                    = $squid::params::cache_dirs,
   $daemon_user                   = $squid::params::daemon_user,
   $daemon_group                  = $squid::params::daemon_group,
+  $ssl_bump                      = $squid::params::ssl_bump,
+  $sslproxy_cert_error           = $squid::params::sslproxy_cert_error,
   $extra_config_sections         = {},
 ) inherits ::squid::params {
 
@@ -70,6 +72,12 @@ class squid (
   }
   if $cache_dirs {
     validate_hash($cache_dirs)
+  }
+  if $ssl_bump {
+    validate_hash($ssl_bump)
+  }
+  if $sslproxy_cert_error {
+    validate_hash($sslproxy_cert_error)
   }
 
   validate_hash($extra_config_sections)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,8 @@ class squid::params {
   $http_ports                    = undef
   $https_ports                   = undef
   $snmp_ports                    = undef
+  $ssl_bump                      = undef
+  $sslproxy_cert_error           = undef
   $cache_dirs                    = undef
   $logformat                     = undef
 

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -1,0 +1,17 @@
+define squid::ssl_bump (
+  $action = 'bump',
+  $value  = $title,
+  $order   = '05',
+) {
+
+  validate_re($action,['^splice$','^bump$','^peek$','^stare$','^terminate$','^client-first$','^server-first$','^peek-and-splice$','^none$'])
+  validate_string($value)
+
+
+  concat::fragment{"squid_ssl_bump_${action}_${value}":
+    target  => $squid::config,
+    content => template('squid/squid.conf.ssl_bump.erb'),
+    order   => "25-${order}-${action}",
+  }
+
+}

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -1,0 +1,17 @@
+define squid::sslproxy_cert_error (
+  $action = 'allow',
+  $value  = $title,
+  $order   = '05',
+) {
+
+  validate_re($action,['^allow$','^deny$'])
+  validate_string($value)
+
+
+  concat::fragment{"squid_sslproxy_cert_error_${action}_${value}":
+    target  => $squid::config,
+    content => template('squid/squid.conf.sslproxy_cert_error.erb'),
+    order   => "35-${order}-${action}",
+  }
+
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -167,6 +167,44 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_http_access_this too').with_content(%r{^http_access\s+deny\s+this too$}) }
       end
 
+      context 'with one ssl_bump parameter set' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            ssl_bump: {
+              'myrule' => {
+                'action' => 'bump',
+                'value' => 'step1',
+                'order' => '08'
+              }
+            }
+          }
+        end
+        it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_bump_step1').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_bump_step1').with_order('25-08-bump') }
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_bump_step1').with_content(%r{^ssl_bump\s+bump\s+step1$}) }
+      end
+
+      context 'with one sslproxy_cert_error parameter set' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            sslproxy_cert_error: {
+              'myrule' => {
+                'action' => 'allow',
+                'value' => 'all',
+                'order' => '08'
+              }
+            }
+          }
+        end
+        it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_allow_all').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_allow_all').with_order('35-08-allow') }
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_allow_all').with_content(%r{^sslproxy_cert_error\s+allow\s+all$}) }
+      end
+
       context 'with http_port parameters set' do
         let :params do
           { config: '/tmp/squid.conf',

--- a/spec/defines/ssl_bump_spec.rb
+++ b/spec/defines/ssl_bump_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'squid::ssl_bump' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let :pre_condition do
+        ' class{"::squid":
+           config => "/tmp/squid.conf"
+         }
+        '
+      end
+      let(:title) { 'myrule' }
+      context 'when parameters are unset' do
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_bump_myrule').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_bump_myrule').with_order('25-05-bump') }
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_bump_myrule').with_content(%r{^ssl_bump\s+bump\s+myrule$}) }
+      end
+      context 'when parameters are set' do
+        let(:params) do
+          {
+            action: 'peek',
+            value: 'step1',
+            order: '08'
+          }
+        end
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_peek_step1').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_peek_step1').with_order('25-08-peek') }
+        it { is_expected.to contain_concat_fragment('squid_ssl_bump_peek_step1').with_content(%r{^ssl_bump\s+peek\s+step1$}) }
+      end
+    end
+  end
+end

--- a/spec/defines/sslproxy_cert_error.rb
+++ b/spec/defines/sslproxy_cert_error.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'squid::sslproxy_cert_error' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let :pre_condition do
+        ' class{"::squid":
+           config => "/tmp/squid.conf"
+         }
+        '
+      end
+      let(:title) { 'myrule' }
+      context 'when parameters are unset' do
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_allow_myrule').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_allow_myrule').with_order('35-05-allow') }
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_allow_myrule').with_content(%r{^sslproxy_cert_error\s+allow\s+myrule$}) }
+      end
+      context 'when parameters are set' do
+        let(:params) do
+          {
+            action: 'deny',
+            value: 'this and that',
+            order: '08'
+          }
+        end
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_deny_this and that').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_deny_this and that').with_order('35-08-deny') }
+        it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_deny_this and that').with_content(%r{^sslproxy_cert_error\s+deny\s+this and that$}) }
+      end
+    end
+  end
+end

--- a/templates/squid.conf.ssl_bump.erb
+++ b/templates/squid.conf.ssl_bump.erb
@@ -1,0 +1,3 @@
+# ssl_bump fragment for <%= @value %>
+ssl_bump <%= @action %> <%= @value %>
+

--- a/templates/squid.conf.sslproxy_cert_error.erb
+++ b/templates/squid.conf.sslproxy_cert_error.erb
@@ -1,0 +1,3 @@
+# sslproxy_cert_error fragment for <%= @value %>
+sslproxy_cert_error <%= @action %> <%= @value %>
+


### PR DESCRIPTION
Howdy!  This PR adds support for the ssl_bump and sslproxy_cert_error types.  (very similar to some of the other types)  I am afraid I have not actually tested the spec test components of the PR, so please let me know if they fail miserably.
