### PR TITLE
Add support for icp_access configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `http_access` defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. [http_access entries](http://www.squid-cache.org/Doc/config/http_access/).
 * `http_ports` defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. [http_port entries](http://www.squid-cache.org/Doc/config/http_port/).
 * `https_ports` defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. [https_port entries](http://www.squid-cache.org/Doc/config/https_port/).
+* `icp_access` defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. [icp_access entries](http://www.squid-cache.org/Doc/config/icp_access/).
 * `snmp_ports` defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. [snmp_port entries](http://www.squid-cache.org/Doc/config/snmp_port/).
 * `cache_dirs` defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. [cache_dir entries](http://www.squid-cache.org/Doc/config/cache_dir/).
 * `extra_config_sections` defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
@@ -155,6 +156,23 @@ Adds a squid.conf line
 
 ```
 http_access allow our_networks hosts
+```
+
+These may be defined as a hash passed to ::squid
+
+### Defined Type squid::icp\_access
+Defines [icp_access entries](http://www.squid-cache.org/Doc/config/icp_access/) for a squid server.
+
+```puppet
+squid::icp_access{'our_networks hosts':
+  action => 'allow',
+}
+```
+
+Adds a squid.conf line 
+
+```
+icp_access allow our_networks hosts
 ```
 
 These may be defined as a hash passed to ::squid

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,7 @@ class squid::config (
   $workers                       = $::squid::workers,
   $acls                          = $::squid::acls,
   $http_access                   = $::squid::http_access,
+  $icp_access                    = $::squid::icp_access,
   $auth_params                   = $::squid::auth_params,
   $http_ports                    = $::squid::http_ports,
   $https_ports                   = $::squid::https_ports,
@@ -37,6 +38,9 @@ class squid::config (
   }
   if $http_access {
     create_resources('squid::http_access', $http_access)
+  }
+  if $icp_access {
+    create_resources('squid::icp_access', $icp_access)
   }
   if $auth_params {
     create_resources('squid::auth_param', $auth_params)

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -1,0 +1,17 @@
+define squid::icp_access (
+  $action = 'allow',
+  $value  = $title,
+  $order   = '05',
+) {
+
+  validate_re($action,['^allow$','^deny$'])
+  validate_string($value)
+
+
+  concat::fragment{"squid_icp_access_${value}":
+    target  => $squid::config,
+    content => template('squid/squid.conf.icp_access.erb'),
+    order   => "30-${order}-${action}",
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class squid (
   $workers                       = $squid::params::workers,
   $acls                          = $squid::params::acls,
   $http_access                   = $squid::params::http_access,
+  $icp_access                    = $squid::params::icp_access,
   $auth_params                   = $squid::params::auth_params,
   $http_ports                    = $squid::params::http_ports,
   $https_ports                   = $squid::params::https_ports,
@@ -55,6 +56,9 @@ class squid (
   }
   if $http_access {
     validate_hash($http_access)
+  }
+  if $icp_access {
+    validate_hash($icp_access)
   }
   if $auth_params {
     validate_hash($auth_params)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class squid::params {
   $workers                       = undef
   $acls                          = undef
   $http_access                   = undef
+  $icp_access                    = undef
   $auth_params                   = undef
   $http_ports                    = undef
   $https_ports                   = undef

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -167,6 +167,53 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_http_access_this too').with_content(%r{^http_access\s+deny\s+this too$}) }
       end
 
+      context 'with one icp_access parameter set' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            icp_access: {
+              'myrule' => {
+                'action' => 'deny',
+                'value' => 'this and that',
+                'order' => '08'
+              }
+            }
+          }
+        end
+        it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_order('30-08-deny') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_content(%r{^icp_access\s+deny\s+this and that$}) }
+      end
+
+      context 'with two icp_access parameters set' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            icp_access: {
+              'myrule' => {
+                'action' => 'deny',
+                'value'  => 'this and that',
+                'order'  => '08'
+              },
+              'secondrule' => {
+                'action' => 'deny',
+                'value'  => 'this too',
+                'order'  => '09'
+              }
+            }
+
+          }
+        end
+        it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_order('30-08-deny') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_content(%r{^icp_access\s+deny\s+this and that$}) }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this too').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this too').with_order('30-09-deny') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this too').with_content(%r{^icp_access\s+deny\s+this too$}) }
+      end
+
       context 'with http_port parameters set' do
         let :params do
           { config: '/tmp/squid.conf',

--- a/spec/defines/icp_access.rb
+++ b/spec/defines/icp_access.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'squid::icp_access' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let :pre_condition do
+        ' class{"::squid":
+           config => "/tmp/squid.conf"
+         }
+        '
+      end
+      let(:title) { 'myrule' }
+      context 'when parameters are unset' do
+        it { is_expected.to contain_concat_fragment('squid_icp_access_myrule').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_myrule').with_order('30-05-allow') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_myrule').with_content(%r{^icp_access\s+allow\s+myrule$}) }
+      end
+      context 'when parameters are set' do
+        let(:params) do
+          {
+            action: 'deny',
+            value: 'this and that',
+            order: '08'
+          }
+        end
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_order('30-08-deny') }
+        it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_content(%r{^icp_access\s+deny\s+this and that$}) }
+      end
+    end
+  end
+end

--- a/templates/squid.conf.icp_access.erb
+++ b/templates/squid.conf.icp_access.erb
@@ -1,0 +1,3 @@
+# icp_access fragment for <%= @value %>
+icp_access <%= @action %> <%= @value %>
+


### PR DESCRIPTION
This PR adds support for icp_access ACLs as documented at http://www.squid-cache.org/Doc/config/icp_access/