### PR TITLE
Set min version_requirement for Puppet + bump deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,14 +13,20 @@
     "http",
     "web"
   ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 < 5.0.0"
+    }
+  ],
   "dependencies": [
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">= 1.0.4"
+      "version_requirement": ">= 1.2.5 < 3.0.0"
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata