### PR TITLE
Fix ordering issue with missing squid user/group for cache_dir

### DIFF
--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -20,10 +20,11 @@ define squid::cache_dir (
   }
 
   file{$path:
-    ensure => directory,
-    owner  => $::squid::daemon_user,
-    group  => $::squid::daemon_group,
-    mode   => '0750',
+    ensure  => directory,
+    owner   => $::squid::daemon_user,
+    group   => $::squid::daemon_group,
+    mode    => '0750',
+    require => Package[$::squid::package_name],
   }
 
 }


### PR DESCRIPTION
When configuring the cache_dir, it's possible that the define squid::cache_dir is called before the package is installed together with the squid user entry in /etc/passwd.

This results in the cache_dir directory trying to change ownership to an unexisting user/group.

The change requires the squid package to be installed before the define is being applied.

Signed-off-by: Christophe Vanlancker <christophe.vanlancker@inuits.eu>