### PR TITLE
When specifying the extra_config_sections as an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ class{'::squid':
                                    'http://example.com/anotherpath'],
                        },
                   },
-  http_access  => { 'our_networks hosts' => { action => 'allow', },
-  http_ports   => { '10000' => { options => 'accel vhost'} },
-  snmp_ports   => { '1000' => { process_number => 3 },
-  cache_dirs   => { '/data/' => { type => 'ufs', options => '15000 32 256 min-size=32769', process_number => 2 }},
+  http_access  => { 'our_networks hosts' => { action => 'allow', }},
+  http_ports   => { '10000' => { options => 'accel vhost', }},
+  snmp_ports   => { '1000' => { process_number => 3, }},
+  cache_dirs   => { '/data/' => { type => 'ufs', options => '15000 32 256 min-size=32769', process_number => 2, }},
 }
 ```
 
@@ -422,6 +422,30 @@ Results in a squid configuration of
 # mail settings
 mail_from squid@example.com
 mail_program mail
+```
+
+And using an array:
+
+```puppet
+squid::extra_config_section { 'refresh patterns':
+  order          => '60',
+  config_entries => [{
+    'refresh_pattern' => ['^ftp:           1440    20%     10080',
+                          '^gopher:        1440    0%      1440',
+                          '-i (/cgi-bin/|\?) 0     0%      0',
+                          '.               0       20%     4320'],
+  }],
+}
+```
+
+Results in a squid configuration of
+
+```
+# refresh_patterns
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern .               0       20%     4320
 ```
 
 #### Parameters for Type squid::extra\_config\_section

--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -1,7 +1,7 @@
 define squid::extra_config_section (
-  String $comment = $title,
-  Hash   $config_entries = {},
-  String $order   = '60',
+  String              $comment = $title,
+  Variant[Array,Hash] $config_entries = {},
+  String              $order   = '60',
 ) {
 
   concat::fragment{"squid_extra_config_section_${comment}":
@@ -9,5 +9,4 @@ define squid::extra_config_section (
     content => template('squid/squid.conf.extra_config_section.erb'),
     order   => "${order}-${comment}",
   }
-
 }

--- a/templates/squid.conf.extra_config_section.erb
+++ b/templates/squid.conf.extra_config_section.erb
@@ -1,5 +1,15 @@
 # <%= @comment %>
+<% if @config_entries.is_a?(Array) -%>
+<% @config_entries.each do |i| -%>
+<% i.each do |k, v| -%>
+<% v.each do |v2| -%>
+<%= k %> <%= v2 %>
+<% end -%>
+<% end -%>
+<% end -%>
+<% else -%>
 <% @config_entries.each do |k,v| -%>
 <%= k %> <%= v.is_a?(Array) ? v.join(' ') : v %>
+<% end -%>
 <% end -%>
 


### PR DESCRIPTION
the entries are set on multiple lines instead of joined on the same line

also fixed an error in the example which was missing some }

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
