### PR TITLE
Feature comments : allow acl and http_access to take $comment parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ squid::http_access{'our_networks hosts':
 Adds a squid.conf line 
 
 ```
+# http_access fragment for out_networks hosts
+http_access allow our_networks hosts
+```
+
+```puppet
+squid::http_access{'our_networks hosts':
+  action    => 'allow',
+  comment   => 'Our networks hosts are allowed',
+}
+```
+
+Adds a squid.conf line
+
+```
+# Our networks hosts are allowed
 http_access allow our_networks hosts
 ```
 

--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -3,10 +3,13 @@ define squid::acl (
   $aclname = $title,
   $entries = [],
   $order   = '05',
+  $comment = "acl fragment for ${aclname}",
+
 ) {
 
   validate_string($type)
   validate_string($aclname)
+  validate_string($comment)
   validate_array($entries)
 
 

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -2,10 +2,12 @@ define squid::http_access (
   $action = 'allow',
   $value  = $title,
   $order   = '05',
+  $comment = "http_access fragment for ${value}"
 ) {
 
   validate_re($action,['^allow$','^deny$'])
   validate_string($value)
+  validate_string($comment)
 
 
   concat::fragment{"squid_http_access_${value}":

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -107,7 +107,7 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_order('10-07-urlregex') }
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.org/$}) }
-        it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.com/$}) }
+        it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^# acl fragment for myacl$}) }
       end
 
       context 'with two acl parameters set' do
@@ -167,9 +167,10 @@ describe 'squid' do
                 'order'  => '08'
               },
               'secondrule' => {
-                'action' => 'deny',
-                'value'  => 'this too',
-                'order'  => '09'
+                'action'  => 'deny',
+                'value'   => 'this too',
+                'order'   => '09',
+                'comment' => 'Deny this and too'
               }
             }
 
@@ -179,9 +180,11 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_order('20-08-deny') }
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_content(%r{^http_access\s+deny\s+this and that$}) }
+        it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_content(%r{^# http_access fragment for this and that$}) }
         it { is_expected.to contain_concat_fragment('squid_http_access_this too').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment('squid_http_access_this too').with_order('20-09-deny') }
         it { is_expected.to contain_concat_fragment('squid_http_access_this too').with_content(%r{^http_access\s+deny\s+this too$}) }
+        it { is_expected.to contain_concat_fragment('squid_http_access_this too').with_content(%r{^# Deny this and too$}) }
       end
 
       context 'with one ssl_bump parameter set' do

--- a/spec/defines/acl_spec.rb
+++ b/spec/defines/acl_spec.rb
@@ -18,13 +18,15 @@ describe 'squid::acl' do
           {
             type: 'urlregex',
             order: '07',
-            entries: ['http://example.org/', 'http://example.com/']
+            entries: ['http://example.org/', 'http://example.com/'],
+            comment: 'Example company website'
           }
         end
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_order('10-07-urlregex') }
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.org/$}) }
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.com/$}) }
+        it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^# Example company website$}) }
       end
     end
   end

--- a/spec/defines/http_access_spec.rb
+++ b/spec/defines/http_access_spec.rb
@@ -17,18 +17,21 @@ describe 'squid::http_access' do
         it { is_expected.to contain_concat_fragment('squid_http_access_myrule').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment('squid_http_access_myrule').with_order('20-05-allow') }
         it { is_expected.to contain_concat_fragment('squid_http_access_myrule').with_content(%r{^http_access\s+allow\s+myrule$}) }
+        it { is_expected.to contain_concat_fragment('squid_http_access_myrule').with_content(%r{^# http_access fragment for myrule$}) }
       end
       context 'when parameters are set' do
         let(:params) do
           {
             action: 'deny',
             value: 'this and that',
-            order: '08'
+            order: '08',
+            comment: 'Deny this and that'
           }
         end
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_order('20-08-deny') }
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_content(%r{^http_access\s+deny\s+this and that$}) }
+        it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_content(%r{^# Deny this and that$}) }
       end
     end
   end

--- a/templates/squid.conf.acl.erb
+++ b/templates/squid.conf.acl.erb
@@ -1,4 +1,4 @@
-# acl fragment for <%= @aclname %>
+# <%= @comment %>
 <% @entries.sort.each do |e| -%>
 acl <%= @aclname %> <%= @type %> <%= e %>
 <% end -%>

--- a/templates/squid.conf.http_access.erb
+++ b/templates/squid.conf.http_access.erb
@@ -1,3 +1,3 @@
-# http_access fragment for <%= @value %>
+# <%= @comment %>
 http_access <%= @action %> <%= @value %>
 


### PR DESCRIPTION
I would like to have a customizable comment within the squid config file as it is sometimes read by system administrator directly on the system itself.

If you agree with such additional feature, I would also changes all other defined types (https_port, icp_access...) so everything would be coherent, as well as I would update the README.md accordingly.

I might also suggest that a $comment value of undef would completely remove it:
```puppet
squid::http_access { 'foo':
  action  => 'allow' ,
  comment => undef,
}
```


Regards,