### PR TITLE
Sanitise type

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -12,11 +12,12 @@ define squid::acl (
   validate_string($comment)
   validate_array($entries)
 
+  $type_cleaned = regsubst($type,':','','G')
 
   concat::fragment{"squid_acl_${aclname}":
     target  => $::squid::config,
     content => template('squid/squid.conf.acl.erb'),
-    order   => "10-${order}-${type}",
+    order   => "10-${order}-${type_cleaned}",
   }
 
 }

--- a/spec/defines/acl_spec.rb
+++ b/spec/defines/acl_spec.rb
@@ -33,7 +33,7 @@ describe 'squid::acl' do
           {
             type: 'ssl::servername',
             order: '07',
-	    entries: ['.foo.bar',],
+	          entries: ['.foo.bar'],
             comment: 'Example company website'
           }
         end


### PR DESCRIPTION
I was installing a new squid proxy with some acl rules. One of these rules was the following

```
squid::acl{'url':
   type    => 'ssl::server_name',
   entries => ['.foo.bar'],
}
```

This returned an Puppet error 
```
Error: Evaluation Error: Error while evaluating a Function Call, Order cannot contain '/', ':', or '
```

By removing the `:` it was fixed.
