### PR TITLE
RFC: Convert to puppet 4/5 data types

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -1,17 +1,10 @@
 define squid::acl (
-  $type,
-  $aclname = $title,
-  $entries = [],
-  $order   = '05',
-  $comment = "acl fragment for ${aclname}",
-
+  String $type,
+  String $aclname = $title,
+  Array  $entries = [],
+  String $order   = '05',
+  String $comment = "acl fragment for ${aclname}",
 ) {
-
-  validate_string($type)
-  validate_string($aclname)
-  validate_string($comment)
-  validate_array($entries)
-
 
   concat::fragment{"squid_acl_${aclname}":
     target  => $::squid::config,

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -1,15 +1,10 @@
 define squid::auth_param (
-  $scheme,
-  $entries,
-  $auth_param_name = $title,
-  $order   = '40',
+  Enum['basic', 'digest']
+          $scheme,
+  Array   $entries,
+  String  $auth_param_name = $title,
+  String  $order           = '40',
 ) {
-
-  validate_string($scheme)
-  validate_re($scheme,['^basic$','^digest$'])
-  validate_string($auth_param_name)
-  validate_array($entries)
-
 
   concat::fragment{"squid_auth_param_${auth_param_name}":
     target  => $::squid::config,

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -1,17 +1,10 @@
 define squid::cache_dir (
-  $type           = ufs,
-  $path           = $title,
-  $options        = '',
-  $process_number = undef,
-  $order          = '05',
+  String            $type           = ufs,
+  String            $path           = $title,
+  String            $options        = '',
+  Optional[Integer] $process_number = undef,
+  String            $order          = '05',
 ) {
-
-  validate_string($type)
-  validate_string($path)
-  validate_string($options)
-  if $process_number {
-    validate_integer($process_number)
-  }
 
   concat::fragment{"squid_cache_dir_${path}":
     target  => $squid::config,

--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -1,11 +1,8 @@
 define squid::extra_config_section (
-  $comment = $title,
-  $config_entries = {},
-  $order   = '60',
+  String $comment = $title,
+  Hash   $config_entries = {},
+  String $order   = '60',
 ) {
-
-  validate_string($comment)
-  validate_hash($config_entries)
 
   concat::fragment{"squid_extra_config_section_${comment}":
     target  => $::squid::config,

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -1,14 +1,10 @@
 define squid::http_access (
-  $action = 'allow',
-  $value  = $title,
-  $order   = '05',
-  $comment = "http_access fragment for ${value}"
+  Enum['allow', 'deny']
+          $action  = 'allow',
+  String  $value   = $title,
+  String  $order   = '05',
+  String  $comment = "http_access fragment for ${value}"
 ) {
-
-  validate_re($action,['^allow$','^deny$'])
-  validate_string($value)
-  validate_string($comment)
-
 
   concat::fragment{"squid_http_access_${value}":
     target  => $squid::config,

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -1,13 +1,10 @@
 define squid::http_port (
-  $port    = $title,
-  $ssl     = false,
-  $options = '',
-  $order   = '05',
+  Variant[Pattern[/\d+/], Integer]
+          $port    = $title,
+  Boolean $ssl     = false,
+  String  $options = '',
+  String  $order   = '05',
 ) {
-
-  validate_bool($ssl)
-  validate_integer($port)
-  validate_string($options)
 
   $protocol = $ssl ? {
     true    => 'https',

--- a/manifests/https_port.pp
+++ b/manifests/https_port.pp
@@ -1,11 +1,9 @@
 define squid::https_port (
-  $port    = $title,
-  $options = '',
-  $order   = '05',
+  Variant[Pattern[/\d+/], Integer]
+          $port    = $title,
+  String  $options = '',
+  String  $order   = '05',
 ) {
-
-  validate_integer($port)
-  validate_string($options)
 
   squid::http_port { "${port}": # lint:ignore:only_variable_string
     ssl     => true,

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -1,12 +1,9 @@
 define squid::icp_access (
-  $action = 'allow',
-  $value  = $title,
-  $order   = '05',
+  Enum['allow', 'deny']
+          $action = 'allow',
+  String  $value  = $title,
+  String  $order  = '05',
 ) {
-
-  validate_re($action,['^allow$','^deny$'])
-  validate_string($value)
-
 
   concat::fragment{"squid_icp_access_${value}":
     target  => $squid::config,

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -1,15 +1,10 @@
 define squid::snmp_port (
-  $port           = $title,
-  $options        = '',
-  $process_number = undef,
-  $order          = '05',
+  Variant[Pattern[/\d+/], Integer]
+                    $port           = $title,
+  String            $options        = '',
+  String            $order          = '05',
+  Optional[Integer] $process_number = undef,
 ) {
-
-  validate_integer($port)
-  validate_string($options)
-  if $process_number {
-    validate_integer($process_number)
-  }
 
   concat::fragment{"squid_snmp_port_${port}":
     target  => $squid::config,

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -1,12 +1,18 @@
 define squid::ssl_bump (
-  $action = 'bump',
-  $value  = $title,
-  $order   = '05',
+  Enum[
+    'bump',
+    'client-first',
+    'none',
+    'peek',
+    'peek-and-splice',
+    'server-first',
+    'splice',
+    'stare',
+    'terminate']
+          $action = 'bump',
+  String  $value  = $title,
+  String  $order  = '05',
 ) {
-
-  validate_re($action,['^splice$','^bump$','^peek$','^stare$','^terminate$','^client-first$','^server-first$','^peek-and-splice$','^none$'])
-  validate_string($value)
-
 
   concat::fragment{"squid_ssl_bump_${action}_${value}":
     target  => $squid::config,

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -1,12 +1,9 @@
 define squid::sslproxy_cert_error (
-  $action = 'allow',
-  $value  = $title,
-  $order   = '05',
+  Enum['allow', 'deny']
+          $action = 'allow',
+  String  $value  = $title,
+  String  $order  = '05',
 ) {
-
-  validate_re($action,['^allow$','^deny$'])
-  validate_string($value)
-
 
   concat::fragment{"squid_sslproxy_cert_error_${action}_${value}":
     target  => $squid::config,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -378,14 +378,14 @@ describe 'squid' do
             config: '/tmp/squid.conf',
             extra_config_sections: {
               'mail settings' => {
-                'order' => 22,
+                'order' => '22',
                 'config_entries' => {
                   'mail_from'    => 'squid@example.com',
                   'mail_program' => 'mail'
                 }
               },
               'other settings' => {
-                'order' => 42,
+                'order' => '42',
                 'config_entries' => {
                   'dns_timeout' => '5 seconds'
                 }

--- a/spec/defines/auth_param_spec.rb
+++ b/spec/defines/auth_param_spec.rb
@@ -14,7 +14,7 @@ describe 'squid::auth_param' do
       end
       let(:title) { 'auth' }
 
-      context 'when parameters are set' do
+      context 'when parameters are set with scheme basic' do
         entries = ['program /usr/lib64/squid/basic_ncsa_auth /etc/squid/.htpasswd',
                    'children 5',
                    'realm Squid Basic Authentication',
@@ -33,6 +33,41 @@ describe 'squid::auth_param' do
         entries.each do |entry|
           it { is_expected.to contain_concat__fragment('squid_auth_param_auth').with_content(%r{auth_param basic #{entry}}) }
         end
+      end
+
+      context 'when parameters are set with scheme digest' do
+        entries = ['program /usr/lib64/squid/basic_ncsa_auth /etc/squid/.htpasswd',
+                   'children 5',
+                   'realm Squid Digest Authentication',
+                   'credentialsttl 5 hours']
+
+        let(:params) do
+          {
+            scheme: 'digest',
+            order: '08',
+            entries: entries
+          }
+        end
+
+        it { is_expected.to contain_concat__fragment('squid_auth_param_auth').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat__fragment('squid_auth_param_auth').with_order('05-08-digest') }
+        entries.each do |entry|
+          it { is_expected.to contain_concat__fragment('squid_auth_param_auth').with_content(%r{auth_param digest #{entry}}) }
+        end
+      end
+
+      context 'when parameters are set with unknown scheme' do
+        entries = ['program /usr/lib64/squid/basic_ncsa_auth /etc/squid/.htpasswd']
+
+        let(:params) do
+          {
+            scheme: 'unknown_scheme',
+            order: '09',
+            entries: entries
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{parameter 'scheme' expects a match}) }
       end
     end
   end

--- a/spec/defines/http_access_spec.rb
+++ b/spec/defines/http_access_spec.rb
@@ -35,6 +35,15 @@ describe 'squid::http_access' do
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_content(%r{^http_access\s+deny\s+this and that$}) }
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_content(%r{^# Deny this and that$}) }
       end
+      context 'with unknown action' do
+        let(:params) do
+          {
+            action: 'unknown_action'
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{parameter 'action' expects a match}) }
+      end
     end
   end
 end

--- a/spec/defines/icp_access_spec.rb
+++ b/spec/defines/icp_access_spec.rb
@@ -32,6 +32,16 @@ describe 'squid::icp_access' do
         it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_order('30-08-deny') }
         it { is_expected.to contain_concat_fragment('squid_icp_access_this and that').with_content(%r{^icp_access\s+deny\s+this and that$}) }
       end
+
+      context 'with unknown action' do
+        let(:params) do
+          {
+            action: 'unknown_action'
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{parameter 'action' expects a match}) }
+      end
     end
   end
 end

--- a/spec/defines/ssl_bump_spec.rb
+++ b/spec/defines/ssl_bump_spec.rb
@@ -32,6 +32,15 @@ describe 'squid::ssl_bump' do
         it { is_expected.to contain_concat_fragment('squid_ssl_bump_peek_step1').with_order('25-08-peek') }
         it { is_expected.to contain_concat_fragment('squid_ssl_bump_peek_step1').with_content(%r{^ssl_bump\s+peek\s+step1$}) }
       end
+      context 'with unknown action' do
+        let(:params) do
+          {
+            action: 'unknown_action'
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{parameter 'action' expects a match}) }
+      end
     end
   end
 end

--- a/spec/defines/sslproxy_cert_error_spec.rb
+++ b/spec/defines/sslproxy_cert_error_spec.rb
@@ -32,6 +32,15 @@ describe 'squid::sslproxy_cert_error' do
         it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_deny_this and that').with_order('35-08-deny') }
         it { is_expected.to contain_concat_fragment('squid_sslproxy_cert_error_deny_this and that').with_content(%r{^sslproxy_cert_error\s+deny\s+this and that$}) }
       end
+      context 'with unknown action' do
+        let(:params) do
+          {
+            action: 'unknown_action'
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{parameter 'action' expects a match}) }
+      end
     end
   end
 end


### PR DESCRIPTION
## RFC
Replace validate_x functions with Puppet data types

Rename 'uncaught' tests
* spec/defines/icp_access.rb
* spec/defines/sslproxy_cert_error.rb

Fix (?) extra_config test, order parameter specified as integer instead of string.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
