### PR TITLE
Update squid.conf.refresh_pattern.erb

### DIFF
--- a/templates/squid.conf.refresh_pattern.erb
+++ b/templates/squid.conf.refresh_pattern.erb
@@ -1,2 +1,2 @@
 # <%= @comment %>
-refresh_pattern <%= @pattern %>: <%= @case_sensitive?'':'-i ' %><%= @min %> <%= @percent %>% <%= @max %><%= @options ? @options:'' %>
+refresh_pattern <%= @case_sensitive?'':'-i ' %><%= @pattern %>: <%= @min %> <%= @percent %>% <%= @max %><%= @options ? @options:'' %>


### PR DESCRIPTION
With previous variant of code  '-i' will be in the parameter section of conf file and squid will fail with those parameters in config file. 
Part of squid conf: 
 "# refresh_pattern fragment for (/cgi-bin/|\?)
 refresh_pattern (/cgi-bin/|\?): -i 0 0% 0"
Error: 
"squid[19613]: FATAL: Bungled /etc/squid/squid.conf line 31: refresh_pattern (/cgi-bin/|\?): -i 0 0% 0"

Should be in conf file: 
 "# refresh_pattern fragment for (/cgi-bin/|\?)
 refresh_pattern -i (/cgi-bin/|\?): 0 0% 0"

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
