### PR TITLE
Sanitise type

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -6,10 +6,12 @@ define squid::acl (
   String $comment = "acl fragment for ${aclname}",
 ) {
 
+  $type_cleaned = regsubst($type,':','','G')
+
   concat::fragment{"squid_acl_${aclname}":
     target  => $::squid::config,
     content => template('squid/squid.conf.acl.erb'),
-    order   => "10-${order}-${type}",
+    order   => "10-${order}-${type_cleaned}",
   }
 
 }

--- a/spec/defines/acl_spec.rb
+++ b/spec/defines/acl_spec.rb
@@ -30,6 +30,18 @@ describe 'squid::acl' do
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^acl\s+myacl\s+urlregex\shttp://example.com/$}) }
         it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_content(%r{^# Example company website$}) }
       end
+      context 'when type contains special characters, a :' do
+        let(:params) do
+          {
+            type: 'ssl::servername',
+            order: '07',
+            entries: ['.foo.bar'],
+            comment: 'Example company website'
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_acl_myacl').with_order('10-07-sslservername') }
+      end
     end
   end
 end


### PR DESCRIPTION
I was installing a new squid proxy with some acl rules. One of these rules was the following

```
squid::acl{'url':
   type    => 'ssl::server_name',
   entries => ['.foo.bar'],
}
```

This returned an Puppet error
```
Error: Evaluation Error: Error while evaluating a Function Call, Order cannot contain '/', ':', or '
```

By removing the `:` it was fixed.

This is a rebased version of GH-53.

Closes GH-53