### PR TITLE
Remove spurious ':' from refresh_pattern template

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ As an alternative to using the Squid::Http\_port defined type with `ssl` set to 
 Defines [refresh_pattern entries](http://www.squid-cache.org/Doc/config/refresh_pattern/) for a squid server.
 
 ```puppet
-squid::refresh_pattern { '^ftp':
+squid::refresh_pattern { '^ftp:':
   min     => 1440,
   max     => 10080,
   percent => 20,
@@ -310,7 +310,7 @@ would result in the following squid refresh patterns
 # refresh_pattern fragment for ^ftp
 refresh_pattern ^ftp: 1440 20% 10080
 # refresh_pattern fragment for (/cgi-bin/|\?)
-refresh_pattern (/cgi-bin/|\?): -i 0 0% 0
+refresh_pattern (/cgi-bin/|\?) -i 0 0% 0
 ```
 
 These may be defined as a hash passed to ::squid

--- a/spec/defines/refresh_pattern_spec.rb
+++ b/spec/defines/refresh_pattern_spec.rb
@@ -28,8 +28,27 @@ describe 'squid::refresh_pattern' do
         fname = 'squid_refresh_pattern_my_pattern'
         it { is_expected.to contain_concat_fragment(fname).with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment(fname).with_order('45-06') }
-        it { is_expected.to contain_concat_fragment(fname).with_content(%r{^refresh_pattern\s+my_pattern:\s+1440\s+20%\s+10080$}) }
+        it { is_expected.to contain_concat_fragment(fname).with_content(%r{^refresh_pattern\s+my_pattern\s+1440\s+20%\s+10080$}) }
       end # context 'when parameters are set'
+
+      context 'when parameters are set and options' do
+        let(:title) { 'my_pattern' }
+        let(:params) do
+          {
+            order:   '06',
+            max:     10_080,
+            min:     1440,
+            percent: 20,
+            options: 'override-expire ignore-no-cache',
+            comment: 'Refresh Patterns'
+          }
+        end
+
+        fname = 'squid_refresh_pattern_my_pattern'
+        it { is_expected.to contain_concat_fragment(fname).with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment(fname).with_order('45-06') }
+        it { is_expected.to contain_concat_fragment(fname).with_content(%r{^refresh_pattern\s+my_pattern\s+1440\s+20%\s+10080\s+override-expire\s+ignore-no-cache$}) }
+      end
 
       context 'when parameters are set and case insensitive' do
         let(:title) { 'case_insensitive' }
@@ -47,7 +66,7 @@ describe 'squid::refresh_pattern' do
         fname = 'squid_refresh_pattern_case_insensitive'
         it { is_expected.to contain_concat_fragment(fname).with_target('/tmp/squid.conf') }
         it { is_expected.to contain_concat_fragment(fname).with_order('45-07') }
-        it { is_expected.to contain_concat_fragment(fname).with_content(%r{^refresh_pattern\s+case_insensitive:\s+-i\s+0\s+0%\s+0$}) }
+        it { is_expected.to contain_concat_fragment(fname).with_content(%r{^refresh_pattern\s+-i\s+case_insensitive\s+0\s+0%\s+0$}) }
       end # context 'when parameters are set and case insensitive'
     end
   end

--- a/templates/squid.conf.refresh_pattern.erb
+++ b/templates/squid.conf.refresh_pattern.erb
@@ -1,2 +1,2 @@
 # <%= @comment %>
-refresh_pattern <%= @pattern %>: <%= @case_sensitive?'':'-i ' %><%= @min %> <%= @percent %>% <%= @max %><%= @options ? @options:'' %>
+refresh_pattern <%= @case_sensitive?'':'-i ' %><%= @pattern %> <%= @min %> <%= @percent %>% <%= @max %><% if @options != '' %> <%= @options %><% end %>


### PR DESCRIPTION
When using a regexp (when case_sensitive is set to false)
the -i should be placed BEFORE the $name and not after
Also fixed that no space was used between the max and
options field, added rspec for options

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
