### PR TITLE
Puppet3

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `cache_dirs` defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. [cache_dir entries](http://www.squid-cache.org/Doc/config/cache_dir/).
 * `ssl_bump` defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. [ssl_bump entries](http://www.squid-cache.org/Doc/config/ssl_bump/).
 * `sslproxy_cert_error` defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. [sslproxy_cert_error entries](http://www.squid-cache.org/Doc/config/sslproxy_cert_error/).
+* `auth_params` defaults to undef. If you pass in a hash of auth_param entries, they will be defined automatically. [auth_param entries](http://www.squid-cache.org/Doc/config/auth_param/).
 * `extra_config_sections` defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
 
 ```puppet

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ https_port 10001 cert=/etc/squid/ssl_cert/server.cert key=/etc/squid/ssl_cert/se
 ```
 
 #### Parameters for Type squid::http\_port
-* `port` defaults to the namevar and is the port number.
+* `port` defaults to the namevar and is the port number (alternatively it may be a string, like, "<ipv4>:<port>".
 * `options` A string to specify any options for the default. By default and empty string.
 * `ssl` A boolean.  When set to `true` creates [https_port entries](http://www.squid-cache.org/Doc/config/https_port/).  Defaults to `false`.
 

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -6,7 +6,7 @@ define squid::http_port (
 ) {
 
   validate_bool($ssl)
-  validate_integer($port)
+  validate_re("${port}", '^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:)?\d+$')
   validate_string($options)
 
   $protocol = $ssl ? {

--- a/manifests/https_port.pp
+++ b/manifests/https_port.pp
@@ -4,7 +4,7 @@ define squid::https_port (
   $order   = '05',
 ) {
 
-  validate_integer($port)
+  validate_re("${port}", '^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:)?\d+$')
   validate_string($options)
 
   squid::http_port { "${port}": # lint:ignore:only_variable_string

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,17 @@ class squid::params {
   case $::operatingsystem {
     /^(Debian|Ubuntu)$/: {
       case $::operatingsystemrelease {
-        /^(8.*|14\.04)$/: {
+        /^9\..*$/: {
+          $package_name          = 'squid'
+          $service_name          = 'squid'
+          $config                = '/etc/squid/squid.conf'
+          $config_user           = 'root'
+          $config_group          = 'root'
+          $access_log            = 'daemon:/var/log/squid/access.log squid'
+          $daemon_user           = 'proxy'
+          $daemon_group          = 'proxy'
+        }
+        /^(8\..*|14\.04)$/: {
           $package_name          = 'squid3'
           $service_name          = 'squid3'
           $config                = '/etc/squid3/squid.conf'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-squid",
-  "version": "0.4.1-rc0",
+  "version": "0.4.0",
   "author": "Vox Pupuli",
   "summary": "configure squid caching proxy",
   "license": "Apache-2.0",


### PR DESCRIPTION
A couple of minor changes - http_port resources can specify an ipv4 address, and a one line addition to the documentation.