### PR TITLE
Fixes #8 Set selinux context of cache_dir and ports. 

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   forge_modules:
     concat: puppetlabs-concat
     stdlib: puppetlabs-stdlib
+    selinux: puppet-selinux
   symlinks:
    "squid": "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ squid::http_access{ '!Safe_ports':
   action => deny,
 }
 ```
+This module will set the SELINUX-context for the cache_dir and/or port, requires [puppet-selinux](https://github.com/voxpupuli/puppet-selinux)  
 
 ### Parameters for squid Class
 Parameters to the squid class almost map 1 to 1 to squid.conf parameters themselves.

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -20,4 +20,12 @@ define squid::cache_dir (
     require => Package[$::squid::package_name],
   }
 
+  if $facts['selinux'] == true {
+    selinux::fcontext{"selinux fcontext squid_cache_t ${path}":
+      seltype  => 'squid_cache_t',
+      pathspec => "${path}(/.*)?",
+      require  => File[$path],
+    }
+  }
+
 }

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -17,4 +17,15 @@ define squid::http_port (
     order   => "30-${order}",
   }
 
+  if $facts['selinux'] == true {
+    $_port = Integer($port)
+    selinux::port{"selinux port squid_port_t ${_port}":
+      ensure   => 'present',
+      seltype  => 'squid_port_t',
+      protocol => 'tcp',
+      port     => $_port,
+    }
+  }
+
 }
+

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -419,6 +419,42 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_https_port_2001').with_content(%r{^https_port\s+2001\s+special for 2001$}) }
       end
 
+      if facts['osfamily'] == 'RedHat'
+        context 'with http_port parameters set + SELINUX' do
+          let :params do
+            { config: '/tmp/squid.conf',
+              http_ports: { 2000 => { 'options' => 'special for 2000' } } }
+          end
+          let(:facts) do
+            facts.merge(
+              selinux => true
+            )
+          end
+
+          it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+          it { is_expected.to contain_concat_fragment('squid_http_port_2000').with_order('30-05') }
+          it { is_expected.to contain_concat_fragment('squid_http_port_2000').with_content(%r{^http_port\s+2000\s+special for 2000$}) }
+          it { is_expected.to contain_selinux__port('selinux port squid_port_t 2000').with('ensure' => 'present', 'seltype' => 'squid_port_t', 'protocol' => 'tcp', 'port' => '2000') }
+        end
+
+        context 'with https_port parameters set' do
+          let :params do
+            { config: '/tmp/squid.conf',
+              https_ports: { 2001 => { 'options' => 'special for 2001' } } }
+          end
+          let(:facts) do
+            facts.merge(
+              selinux => true
+            )
+          end
+
+          it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+          it { is_expected.to contain_concat_fragment('squid_https_port_2001').with_order('30-05') }
+          it { is_expected.to contain_concat_fragment('squid_https_port_2001').with_content(%r{^https_port\s+2001\s+special for 2001$}) }
+          it { is_expected.to contain_selinux__port('selinux port squid_port_t 2001').with('ensure' => 'present', 'seltype' => 'squid_port_t', 'protocol' => 'tcp', 'port' => '2001') }
+        end
+      end
+
       context 'with snmp_incoming_address parameter set' do
         let :params do
           {
@@ -452,6 +488,25 @@ describe 'squid' do
 
         it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_file('/data').with_ensure('directory') }
+      end
+
+      if facts['osfamily'] == 'RedHat'
+        context 'with cache_dir parameters set + SELINUX' do
+          let :params do
+            { config: '/tmp/squid.conf',
+              cache_dirs: { '/data' => { 'type'    => 'special',
+                                         'options' => 'my options for special type' } } }
+          end
+          let(:facts) do
+            facts.merge(
+              selinux => true
+            )
+          end
+
+          it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+          it { is_expected.to contain_file('/data').with_ensure('directory') }
+          it { is_expected.to contain_selinux__fcontext('selinux fcontext squid_cache_t /data').with('seltype' => 'squid_cache_t', 'pathspec' => '/data(/.*)?') }
+        end
       end
 
       context 'with extra_config_sections parameter set' do


### PR DESCRIPTION
When SELINUX is enabled the cache_dir and port are given
the correct SELINUX context (fcontext & port)
Only works on RedHat and families

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
