### PR TITLE
New defined type squid::send_hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `icp_access` defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. [icp_access entries](http://www.squid-cache.org/Doc/config/icp_access/).
 * `refresh_patterns` defaults to undef.  If you pass a hash of refresh_pattern entires, they will be defined automatically. [refresh_pattern entries](http://www.squid-cache.org/Doc/config/refresh_pattern/).
 * `snmp_ports` defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. [snmp_port entries](http://www.squid-cache.org/Doc/config/snmp_port/).
+* `send_hit` defaults to undef. If you pass in a hash of send_hit entries, they will be defined automatically. [send_hit entries](http://www.squid-cache.org/Doc/config/send_hit/).
 * `cache_dirs` defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. [cache_dir entries](http://www.squid-cache.org/Doc/config/cache_dir/).
 * `ssl_bump` defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. [ssl_bump entries](http://www.squid-cache.org/Doc/config/ssl_bump/).
 * `sslproxy_cert_error` defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. [sslproxy_cert_error entries](http://www.squid-cache.org/Doc/config/sslproxy_cert_error/).
@@ -197,6 +198,27 @@ Adds a squid.conf line
 # Our networks hosts are allowed
 http_access allow our_networks hosts
 ```
+
+### Define Type squid::send\_hit
+Defines [send_hit](http://www.squid-cache.org/Doc/config/send_hit/) for a squid server.
+
+```puppet
+squid:::send_hit{'PragmaNoCache':
+  action => 'deny',
+}
+```
+
+Adds a squid.conf line
+
+```
+send_hit deny PragmaNoCache
+```
+
+#### Parameters for Type squid::send\hit
+`value` defaults to the `namevar`. The rule to allow or deny.
+`action` must one of `deny` or `allow`
+`order` by default is 05.
+`comment` A comment to add to the configuration file.
 
 ### Defined Type squid::snmp\_access
 Defines [snmp_access entries](http://www.squid-cache.org/Doc/config/snmp_access/) for a squid server.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class squid::config (
   $workers                       = $::squid::workers,
   $acls                          = $::squid::acls,
   $http_access                   = $::squid::http_access,
+  $send_hit                      = $::squid::send_hit,
   $snmp_access                   = $::squid::snmp_access,
   $icp_access                    = $::squid::icp_access,
   $auth_params                   = $::squid::auth_params,
@@ -49,6 +50,9 @@ class squid::config (
   }
   if $http_access {
     create_resources('squid::http_access', $http_access)
+  }
+  if $send_hit {
+    create_resources('squid::send_hit', $send_hit)
   }
   if $snmp_access {
     create_resources('squid::snmp_access', $snmp_access)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class squid (
   Optional[String]  $coredump_dir                  = $squid::params::coredump_dir,
   Optional[Hash]    $extra_config_sections         = {},
   Optional[Hash]    $http_access                   = $squid::params::http_access,
+  Optional[Hash]    $send_hit                      = $squid::params::send_hit,
   Optional[Hash]    $snmp_access                   = $squid::params::snmp_access,
   Optional[Hash]    $http_ports                    = $squid::params::http_ports,
   Optional[Hash]    $https_ports                   = $squid::params::https_ports,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class squid::params {
   $acls                          = undef
   $cache                         = undef
   $http_access                   = undef
+  $send_hit                      = undef
   $icp_access                    = undef
   $auth_params                   = undef
   $http_ports                    = undef

--- a/manifests/send_hit.pp
+++ b/manifests/send_hit.pp
@@ -1,0 +1,15 @@
+define squid::send_hit (
+  Enum['allow', 'deny']
+          $action  = 'allow',
+  String  $value   = $title,
+  String  $order   = '05',
+  String  $comment = "send_hit fragment for ${value}"
+) {
+
+  concat::fragment{"squid_send_hit_${value}":
+    target  => $squid::config,
+    content => template('squid/squid.conf.send_hit.erb'),
+    order   => "21-${order}-${action}",
+  }
+
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -244,6 +244,26 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_http_access_this and that').with_content(%r{^http_access\s+deny\s+this and that$}) }
       end
 
+      context 'with one send_hit parameter set' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            send_hit: {
+              'myacl' => {
+                'action' => 'deny',
+                'value' => 'this and that',
+                'order' => '08'
+              }
+            }
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_this and that').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_this and that').with_order('21-08-deny') }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_this and that').with_content(%r{^send_hit\s+deny\s+this and that$}) }
+      end
+
       context 'with two http_access parameters set' do
         let :params do
           {

--- a/spec/defines/send_hit_spec.rb
+++ b/spec/defines/send_hit_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'squid::send_hit' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let :pre_condition do
+        ' class{"::squid":
+           config => "/tmp/squid.conf"
+         }
+        '
+      end
+      let(:title) { 'myrule' }
+
+      context 'when parameters are unset' do
+        it { is_expected.to contain_concat_fragment('squid_send_hit_myrule').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_myrule').with_order('21-05-allow') }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_myrule').with_content(%r{^send_hit\s+allow\s+myrule$}) }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_myrule').with_content(%r{^# send_hit fragment for myrule$}) }
+      end
+      context 'when parameters are set' do
+        let(:params) do
+          {
+            action: 'deny',
+            value: 'this and that',
+            order: '03',
+            comment: 'send_hit this and that'
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_send_hit_this and that').with_target('/tmp/squid.conf') }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_this and that').with_order('21-03-deny') }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_this and that').with_content(%r{^send_hit\s+deny\s+this and that$}) }
+        it { is_expected.to contain_concat_fragment('squid_send_hit_this and that').with_content(%r{^# send_hit this and that$}) }
+      end
+      context 'with unknown action' do
+        let(:params) do
+          {
+            action: 'unknown_action'
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{parameter 'action' expects a match}) }
+      end
+    end
+  end
+end

--- a/templates/squid.conf.send_hit.erb
+++ b/templates/squid.conf.send_hit.erb
@@ -1,0 +1,3 @@
+# <%= @comment %>
+send_hit <%= @action %> <%= @value %>
+


### PR DESCRIPTION
Specifying a `squid::send_hit` allows
a squid configruation line

```
squid_hit deny MyACL
```

to be configured.

http://www.squid-cache.org/Doc/config/send_hit/

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
