### PR TITLE
This commit applies a restorecon when using SELINUX

### DIFF
--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -25,6 +25,11 @@ define squid::cache_dir (
       seltype  => 'squid_cache_t',
       pathspec => "${path}(/.*)?",
       require  => File[$path],
+      notify   => Selinux::Exec_restorecon["selinux restorecon ${path}"],
+    }
+    selinux::exec_restorecon{"selinux restorecon ${path}":
+      path        => $path,
+      refreshonly => true,
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -506,6 +506,8 @@ describe 'squid' do
           it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
           it { is_expected.to contain_file('/data').with_ensure('directory') }
           it { is_expected.to contain_selinux__fcontext('selinux fcontext squid_cache_t /data').with('seltype' => 'squid_cache_t', 'pathspec' => '/data(/.*)?') }
+          it { is_expected.to contain_selinux__fcontext('selinux fcontext squid_cache_t /data').that_notifies('Selinux::Exec_restorecon["restorecon /data"]') }
+          it { is_expected.to contain_selinux__exec_restorecon('selinux restorecon /data').with('path' => '/data') }
         end
       end
 


### PR DESCRIPTION
The cache_dir fcontext was set, but not applied, this
fixes that.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
