### PR TITLE
Use strings not symbols with beaker-puppet `fact()`

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_acceptance'
 
 describe 'squid class' do
   context 'configure http_access' do
-    squid_name = fact(:operatingsystem) == 'Debian' && fact(:operatingsystemmajrelease) == '8' ? 'squid3' : 'squid'
+    squid_name = fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8' ? 'squid3' : 'squid'
 
     it 'works idempotently with no errors' do
       pp = <<-EOS


### PR DESCRIPTION
`beaker-puppet` never indended to support symbols passed to the `fact`
function.  See https://github.com/puppetlabs/beaker-puppet/pull/73

#### This Pull Request (PR) fixes the following issues
```
fact_on's `name` option must be a String. You provided a Symbol: 'operatingsystem'
```
