### PR TITLE
Add a Squid::Size type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class squid (
   String            $access_log                       = $squid::params::access_log,
-  Pattern[/\d+ MB/] $cache_mem                        = $squid::params::cache_mem,
+  Squid::Size       $cache_mem                        = $squid::params::cache_mem,
   String            $config                           = $squid::params::config,
   String            $config_group                     = $squid::params::config_group,
   String            $config_user                      = $squid::params::config_user,
@@ -8,7 +8,7 @@ class squid (
   String            $daemon_user                      = $squid::params::daemon_user,
   Boolean           $enable_service                   = $squid::params::enable_service,
   String            $ensure_service                   = $squid::params::ensure_service,
-  Pattern[/\d+ KB/] $maximum_object_size_in_memory    = $squid::params::maximum_object_size_in_memory,
+  Squid::Size       $maximum_object_size_in_memory    = $squid::params::maximum_object_size_in_memory,
   String            $package_name                     = $squid::params::package_name,
   String            $service_name                     = $squid::params::service_name,
   Optional[Stdlib::Absolutepath] $error_directory     = $squid::params::error_directory,

--- a/spec/type_aliases/squid_size_spec.rb
+++ b/spec/type_aliases/squid_size_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'Squid::Size' do
+  it { is_expected.to allow_value('1 KB') }
+  it { is_expected.to allow_value('1 MB') }
+  it { is_expected.to allow_value('10 KB') }
+  it { is_expected.to allow_value('9876543210 KB') }
+  it { is_expected.not_to allow_value('-1 KB') }
+  it { is_expected.not_to allow_value('1 kB') }
+  it { is_expected.not_to allow_value('1 Kb') }
+  it { is_expected.not_to allow_value('1 Mb') }
+  it { is_expected.not_to allow_value('1 KBB') }
+  it { is_expected.not_to allow_value('a KBB') }
+  it { is_expected.not_to allow_value('1KB') }
+end

--- a/types/size.pp
+++ b/types/size.pp
@@ -1,0 +1,1 @@
+type Squid::Size = Pattern[/^\d+ [KM]B$/]


### PR DESCRIPTION
This type correctly checks the type for sizes. It now allows specifying the maximum_object_size_in_memory in MBs rather than KBs. For correctness we now also check for the full string which means we no longer allow -1 KB or 1 KBB.