### PR TITLE
This commit puts a defined in cache_dir.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ endif
   in a `if $proceess_number` statement so the cache will be used by only
   one process. Default is undef.
 
+NOTE: When creating a custom 'cache_dir' using Puppet (like a seperate mount) this module WILL NOT create the dir (so no duplicate error occurs), be sure the created directory is owned by the user/group 'squid'.
+
 ### Defined Type squid::cache
 Defines [cache entries](http://www.squid-cache.org/Doc/config/cache/) for a squid server.
 

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -12,13 +12,13 @@ define squid::cache_dir (
     order   => "50-${order}",
   }
 
-  file{$path:
+  ensure_resource('file', $path, {
     ensure  => directory,
     owner   => $::squid::daemon_user,
     group   => $::squid::daemon_group,
     mode    => '0750',
     require => Package[$::squid::package_name],
-  }
+  })
 
   if $facts['selinux'] == true {
     selinux::fcontext{"selinux fcontext squid_cache_t ${path}":


### PR DESCRIPTION
Making it possible to create your own cache_dir
outside of the Squid module. Fixing issue #108.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
