### PR TITLE
Added 'manage_dir' parameter to cache_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ endif
 * `process_number` if specfied as an integer the cache will be wrapped
   in a `if $proceess_number` statement so the cache will be used by only
   one process. Default is undef.
+* `manage_dir` Boolean value, if true puppet will attempt to create the 
+  directory, if false you will have to create it yourself. Make sure the
+  directory has the correct owner, group and mode. Defaults to true.
 
 ### Defined Type squid::cache
 Defines [cache entries](http://www.squid-cache.org/Doc/config/cache/) for a squid server.

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -4,6 +4,7 @@ define squid::cache_dir (
   String            $options        = '',
   Optional[Integer] $process_number = undef,
   String            $order          = '05',
+  Boolean           $manage_dir     = true,
 ) {
 
   concat::fragment{"squid_cache_dir_${path}":
@@ -12,12 +13,14 @@ define squid::cache_dir (
     order   => "50-${order}",
   }
 
-  file{$path:
-    ensure  => directory,
-    owner   => $::squid::daemon_user,
-    group   => $::squid::daemon_group,
-    mode    => '0750',
-    require => Package[$::squid::package_name],
+  if $manage_dir {
+    file{$path:
+      ensure  => directory,
+      owner   => $::squid::daemon_user,
+      group   => $::squid::daemon_group,
+      mode    => '0750',
+      require => Package[$::squid::package_name],
+    }
   }
 
   if $facts['selinux'] == true {


### PR DESCRIPTION
#### Pull Request (PR) description

Added an additional parameter 'manage_dir' to the cache_dir class. When set to true (default) the module will attempt to manage the directory, when set to false it will not.

#### This Pull Request (PR) fixes the following issues
Fixes: #108
