### PR TITLE
Validate squid config before applying changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `ssl_bump` defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. [ssl_bump entries](http://www.squid-cache.org/Doc/config/ssl_bump/).
 * `sslproxy_cert_error` defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. [sslproxy_cert_error entries](http://www.squid-cache.org/Doc/config/sslproxy_cert_error/).
 * `extra_config_sections` defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
+* `squid_bin_path` path to the squid binary, default depends on `$operatingsystem`
 
 ```puppet
 class { 'squid':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,13 +37,15 @@ class squid::config (
   $cache_dirs                    = $::squid::cache_dirs,
   $cache                         = $::squid::cache,
   $extra_config_sections         = $::squid::extra_config_sections,
+  $squid_bin_path                = $::squid::squid_bin_path,
 ) inherits squid {
 
-  concat{$config:
-    ensure => present,
-    owner  => $config_user,
-    group  => $config_group,
-    mode   => '0640',
+  concat { $config:
+    ensure       => present,
+    owner        => $config_user,
+    group        => $config_group,
+    mode         => '0640',
+    validate_cmd => "${squid_bin_path} -k parse -f %",
   }
 
   concat::fragment{'squid_header':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class squid (
   Squid::Size       $maximum_object_size_in_memory    = $squid::params::maximum_object_size_in_memory,
   String            $package_name                     = $squid::params::package_name,
   String            $service_name                     = $squid::params::service_name,
+  Stdlib::Absolutepath $squid_bin_path                = $squid::params::squid_bin_path,
   Optional[Stdlib::Absolutepath] $error_directory     = $squid::params::error_directory,
   Optional[Stdlib::Absolutepath] $err_page_stylesheet = $squid::params::err_page_stylesheet,
   Optional[String]  $cache_replacement_policy      = $squid::params::cache_replacement_policy,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,12 +49,14 @@ class squid::params {
           $service_name          = 'squid3'
           $config                = '/etc/squid3/squid.conf'
           $access_log            = 'daemon:/var/log/squid3/access.log squid'
+          $squid_bin_path        = '/usr/sbin/squid3'
         }
         default: {
           $package_name          = 'squid'
           $service_name          = 'squid'
           $config                = '/etc/squid/squid.conf'
           $access_log            = 'daemon:/var/log/squid/access.log squid'
+          $squid_bin_path        = '/usr/sbin/squid'
         }
       }
 
@@ -72,6 +74,7 @@ class squid::params {
       $access_log                = 'daemon:/var/log/squid/access.log squid'
       $daemon_user               = 'squid'
       $daemon_group              = 'squid'
+      $squid_bin_path            = '/usr/sbin/squid'
     }
     default: {
       $package_name              = 'squid'
@@ -82,6 +85,7 @@ class squid::params {
       $access_log                = 'daemon:/var/log/squid/access.log squid'
       $daemon_user               = 'squid'
       $daemon_group              = 'squid'
+      $squid_bin_path            = '/usr/sbin/squid'
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,6 +18,10 @@ describe 'squid' do
         facts[:osfamily] == 'Debian' ? 'root' : 'squid'
       end
 
+      let(:squid_bin_path) do
+        %w[jessie trusty].include?(facts[:lsbdistcodename]) ? '/usr/sbin/squid3' : '/usr/sbin/squid'
+      end
+
       context 'with defaults for all parameters' do
         it { is_expected.to contain_class('squid') }
         it { is_expected.to contain_class('squid::install') }
@@ -28,6 +32,7 @@ describe 'squid' do
         it { is_expected.to contain_service(squid_name).with_ensure('running') }
         it { is_expected.to contain_concat("#{etc_dir}/#{squid_name}/squid.conf").with_group(config_group) }
         it { is_expected.to contain_concat("#{etc_dir}/#{squid_name}/squid.conf").with_owner('root') }
+        it { is_expected.to contain_concat("#{etc_dir}/#{squid_name}/squid.conf").with_validate_cmd("#{squid_bin_path} -k parse -f %") }
         it { is_expected.to contain_concat_fragment('squid_header').with_target("#{etc_dir}/#{squid_name}/squid.conf") }
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^access_log\s+daemon:/var/log/#{squid_name}/access.log\s+squid$}) }
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^cache_mem\s+256 MB$}) }


### PR DESCRIPTION
Rebase of https://github.com/voxpupuli/puppet-squid/pull/122 with also one minor edit.  `Stdlib::Absolutepath` instead of `String` for data type of `squid_bin_path`.