### PR TITLE
Override service restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `ssl_bump` defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. [ssl_bump entries](http://www.squid-cache.org/Doc/config/ssl_bump/).
 * `sslproxy_cert_error` defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. [sslproxy_cert_error entries](http://www.squid-cache.org/Doc/config/sslproxy_cert_error/).
 * `extra_config_sections` defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
+* `service_restart` defaults to undef. Overrides service resource restart command to be executed. It can be used to perform a soft reload of the squid service.
 * `squid_bin_path` path to the squid binary, default depends on `$operatingsystem`
 
 ```puppet

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class squid (
   Optional[Hash]    $ssl_bump                         = $squid::params::ssl_bump,
   Optional[Hash]    $sslproxy_cert_error              = $squid::params::sslproxy_cert_error,
   Optional[Integer] $workers                          = $squid::params::workers,
+  Optional[String]  $service_restart                  = $squid::params::service_restart,
 ) inherits ::squid::params {
 
   anchor{'squid::begin':}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,6 +40,7 @@ class squid::params {
   $logformat                     = undef
   $error_directory               = undef
   $err_page_stylesheet           = undef
+  $service_restart               = undef
   $package_ensure                = 'present'
 
   case $::operatingsystem {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,8 +5,9 @@
 class squid::service inherits squid {
 
   service{$::squid::service_name:
-    ensure => $squid::ensure_service,
-    enable => $squid::enable_service,
+    ensure  => $squid::ensure_service,
+    enable  => $squid::enable_service,
+    restart => $squid::service_restart,
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Allow the override of service restart default command (https://puppet.com/docs/puppet/5.4/types/service.html#service-attribute-restart) so a soft reload of squid service can be performed. I.E.: Using `systemctl reload-or-restart`

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
