### PR TITLE
Change the way SELinux is applied for portnumbers 

### DIFF
--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -54,7 +54,7 @@ define squid::cache_dir (
     }
   }
 
-  if $facts['os']['selinux'] == true {
+  if fact('os.selinux.enabled') {
     selinux::fcontext { "selinux fcontext squid_cache_t ${path}":
       seltype  => 'squid_cache_t',
       pathspec => "${path}(/.*)?",

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -85,12 +85,14 @@ define squid::http_port (
     order   => "30-${order}",
   }
 
-  if $facts['os']['selinux'] == true {
-    selinux::port { "selinux port squid_port_t ${_port}":
-      ensure   => 'present',
-      seltype  => 'squid_port_t',
-      protocol => 'tcp',
-      port     => $_port,
-    }
+  if fact('os.selinux.enabled') {
+    ensure_resource('selinux::port', "selinux port squid_port_t ${_port}",
+      {
+        ensure   => 'present',
+        seltype  => 'squid_port_t',
+        protocol => 'tcp',
+        port     => $_port,
+      }
+    )
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -513,17 +513,13 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_https_port_2001').with_content(%r{^https_port\s+2001\s+special for 2001$}) }
       end
 
-      if facts['osfamily'] == 'RedHat'
+      if facts[:osfamily] == 'RedHat'
         context 'with http_port parameters set + SELINUX' do
           let :params do
             { config: '/tmp/squid.conf',
               http_ports: { 2000 => { 'options' => 'special for 2000' } } }
           end
-          let(:facts) do
-            facts.merge(
-              selinux => true
-            )
-          end
+          let(:facts) { override_facts(super(), os: { selinux: { enabled: true } }) }
 
           it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
           it { is_expected.to contain_concat_fragment('squid_http_port_2000').with_order('30-05') }
@@ -536,16 +532,42 @@ describe 'squid' do
             { config: '/tmp/squid.conf',
               https_ports: { 2001 => { 'options' => 'special for 2001' } } }
           end
-          let(:facts) do
-            facts.merge(
-              selinux => true
-            )
-          end
+          let(:facts) { override_facts(super(), os: { selinux: { enabled: true } }) }
 
           it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
           it { is_expected.to contain_concat_fragment('squid_https_port_2001').with_order('30-05') }
           it { is_expected.to contain_concat_fragment('squid_https_port_2001').with_content(%r{^https_port\s+2001\s+special for 2001$}) }
           it { is_expected.to contain_selinux__port('selinux port squid_port_t 2001').with('ensure' => 'present', 'seltype' => 'squid_port_t', 'protocol' => 'tcp', 'port' => '2001') }
+        end
+
+        context 'with duplicate ports on different ip' do
+          let :params do
+            { config: '/tmp/squid.conf',
+              http_ports: { 'ipA' => { 'port' => 3128, 'host' => '192.168.1.10' }, 'ipB' => { 'port' => 3128, 'host' => '192.168.1.11' } } }
+          end
+
+          let(:facts) { override_facts(super(), os: { selinux: { enabled: true } }) }
+
+          it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+          it { is_expected.to contain_concat_fragment('squid_http_port_ipA').with_order('30-05') }
+          it { is_expected.to contain_concat_fragment('squid_http_port_ipA').with_content(%r{http_port\s+192.168.1.10:3128}) }
+          it { is_expected.to contain_concat_fragment('squid_http_port_ipB').with_order('30-05') }
+          it { is_expected.to contain_concat_fragment('squid_http_port_ipB').with_content(%r{http_port\s+192.168.1.11:3128}) }
+          it { is_expected.to contain_selinux__port('selinux port squid_port_t 3128').with('ensure' => 'present', 'seltype' => 'squid_port_t', 'protocol' => 'tcp', 'port' => '3128') }
+        end
+
+        context 'with cache_dir parameters set + SELINUX' do
+          let :params do
+            { config: '/tmp/squid.conf',
+              cache_dirs: { '/data' => { 'type'    => 'special',
+                                         'options' => 'my options for special type' } } }
+          end
+          let(:facts) { override_facts(super(), os: { selinux: { enabled: true } }) }
+
+          it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
+          it { is_expected.to contain_file('/data').with_ensure('directory') }
+          it { is_expected.to contain_selinux__fcontext('selinux fcontext squid_cache_t /data').with('seltype' => 'squid_cache_t', 'pathspec' => '/data(/.*)?') }
+          it { is_expected.to contain_selinux__exec_restorecon('selinux restorecon /data').with('path' => '/data') }
         end
       end
 
@@ -582,27 +604,6 @@ describe 'squid' do
 
         it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
         it { is_expected.to contain_file('/data').with_ensure('directory') }
-      end
-
-      if facts['osfamily'] == 'RedHat'
-        context 'with cache_dir parameters set + SELINUX' do
-          let :params do
-            { config: '/tmp/squid.conf',
-              cache_dirs: { '/data' => { 'type'    => 'special',
-                                         'options' => 'my options for special type' } } }
-          end
-          let(:facts) do
-            facts.merge(
-              selinux => true
-            )
-          end
-
-          it { is_expected.to contain_concat_fragment('squid_header').with_target('/tmp/squid.conf') }
-          it { is_expected.to contain_file('/data').with_ensure('directory') }
-          it { is_expected.to contain_selinux__fcontext('selinux fcontext squid_cache_t /data').with('seltype' => 'squid_cache_t', 'pathspec' => '/data(/.*)?') }
-          it { is_expected.to contain_selinux__fcontext('selinux fcontext squid_cache_t /data').that_notifies('Selinux::Exec_restorecon["restorecon /data"]') }
-          it { is_expected.to contain_selinux__exec_restorecon('selinux restorecon /data').with('path' => '/data') }
-        end
       end
 
       context 'with extra_config_sections parameter set' do


### PR DESCRIPTION
When declaring serveral http_ports with different IP's, but the same portnumber a resource conflict would arise on the selinux-part. Changed the selinux::port to an "ensure_resource", hence fixing issue #120.