### PR TITLE
support forwarded for

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `visible_hostname` defaults to undef. [visible_hostname docs](http://www.squid-cache.org/Doc/config/visible_hostname/)
 * `via` defaults to undef. [via docs](http://www.squid-cache.org/Doc/config/via/)
 * `httpd_suppress_version_string` defaults to undef. [httpd_suppress_version_string docs](http://www.squid-cache.org/Doc/config/httpd_suppress_version_string/)
-* `forwarded_for` defaults to undef. [forwarded_for docs](http://www.squid-cache.org/Doc/config/forwarded_for/)
+* `forwarded_for` defaults to undef. supported values are "on", "off", "transparent", "delete", "truncate". [forwarded_for docs](http://www.squid-cache.org/Doc/config/forwarded_for/)
 * `http_access` defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. [http_access entries](http://www.squid-cache.org/Doc/config/http_access/).
 * `http_ports` defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. [http_port entries](http://www.squid-cache.org/Doc/config/http_port/).
 * `https_ports` defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. [https_port entries](http://www.squid-cache.org/Doc/config/https_port/).

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class squid (
   Optional[String]  $cache_replacement_policy      = $squid::params::cache_replacement_policy,
   Optional[String]  $memory_replacement_policy     = $squid::params::memory_replacement_policy,
   Optional[Boolean] $httpd_suppress_version_string = $squid::params::httpd_suppress_version_string,
-  Optional[Enum['on', 'off', 'transparent', 'delete', 'truncate']]
+  Optional[Variant[Enum['on', 'off', 'transparent', 'delete', 'truncate'], Boolean]]
                     $forwarded_for                 = $squid::params::forwarded_for,
   Optional[String]  $visible_hostname              = $squid::params::visible_hostname,
   Optional[Boolean] $via                           = $squid::params::via,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,8 @@ class squid (
   Optional[String]  $cache_replacement_policy      = $squid::params::cache_replacement_policy,
   Optional[String]  $memory_replacement_policy     = $squid::params::memory_replacement_policy,
   Optional[Boolean] $httpd_suppress_version_string = $squid::params::httpd_suppress_version_string,
-  Optional[Boolean] $forwarded_for                 = $squid::params::forwarded_for,
+  Optional[Enum['on', 'off', 'transparent', 'delete', 'truncate']]
+                    $forwarded_for                 = $squid::params::forwarded_for,
   Optional[String]  $visible_hostname              = $squid::params::visible_hostname,
   Optional[Boolean] $via                           = $squid::params::via,
   Optional[Hash]    $acls                          = $squid::params::acls,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -183,7 +183,7 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^forwarded_for\s+off$}) }
       end
 
-	  context 'with forwarded_for parameter set to on' do
+      context 'with forwarded_for parameter set to on' do
         let :params do
           {
             config: '/tmp/squid.conf',
@@ -194,7 +194,7 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^forwarded_for\s+on$}) }
       end
 
-	  context 'with forwarded_for parameter set to delete' do
+      context 'with forwarded_for parameter set to delete' do
         let :params do
           {
             config: '/tmp/squid.conf',
@@ -205,7 +205,7 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^forwarded_for\s+delete$}) }
       end
 
-	  context 'with forwarded_for parameter set to transparent' do
+      context 'with forwarded_for parameter set to transparent' do
         let :params do
           {
             config: '/tmp/squid.conf',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -172,6 +172,50 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^memory_cache_shared\s+off$}) }
       end
 
+      context 'with forwarded_for parameter set to off' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            forwarded_for: 'off'
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^forwarded_for\s+off$}) }
+      end
+
+	  context 'with forwarded_for parameter set to on' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            forwarded_for: 'on'
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^forwarded_for\s+on$}) }
+      end
+
+	  context 'with forwarded_for parameter set to delete' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            forwarded_for: 'delete'
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^forwarded_for\s+delete$}) }
+      end
+
+	  context 'with forwarded_for parameter set to transparent' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            forwarded_for: 'transparent'
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^forwarded_for\s+transparent$}) }
+      end
+
       context 'with cache_replacement_policy parameter set to LRU' do
         let :params do
           {

--- a/templates/squid.conf.header.erb
+++ b/templates/squid.conf.header.erb
@@ -59,7 +59,7 @@ via                           <%= @via?'on':'off' %>
 httpd_suppress_version_string <%= @httpd_suppress_version_string?'on':'off' %>
 <% end -%>
 <% unless @forwarded_for.nil? -%>
-forwarded_for                 <%= @forwarded_for?'on':'off' %>
+forwarded_for                 <%= @forwarded_for %>
 <% end -%>
 
 <% if @url_rewrite_program -%>

--- a/templates/squid.conf.header.erb
+++ b/templates/squid.conf.header.erb
@@ -58,12 +58,10 @@ via                           <%= @via?'on':'off' %>
 <% unless @httpd_suppress_version_string.nil? -%>
 httpd_suppress_version_string <%= @httpd_suppress_version_string?'on':'off' %>
 <% end -%>
-<% unless @forwarded_for.nil? -%>
 <% if [true, false].include? @forwarded_for -%>
 forwarded_for                 <%= @forwarded_for?'on':'off' %>
-<% else -%> 
+<% elsif !@forwarded_for.nil? -%> 
 forwarded_for                 <%= @forwarded_for %>
-<% end -%>
 <% end -%>
 
 <% if @url_rewrite_program -%>

--- a/templates/squid.conf.header.erb
+++ b/templates/squid.conf.header.erb
@@ -59,7 +59,11 @@ via                           <%= @via?'on':'off' %>
 httpd_suppress_version_string <%= @httpd_suppress_version_string?'on':'off' %>
 <% end -%>
 <% unless @forwarded_for.nil? -%>
+<% if [true, false].include? @forwarded_for -%>
+forwarded_for                 <%= @forwarded_for?'on':'off' %>
+<% else -%> 
 forwarded_for                 <%= @forwarded_for %>
+<% end -%>
 <% end -%>
 
 <% if @url_rewrite_program -%>


### PR DESCRIPTION
#### Pull Request (PR) description

right now the param "forward_for" is a boolean that allows to set "on" or "off". Squid however can be configured using one of the values: "on", "off", "transparent", "delete", "truncate".
this PR adds support for this..
also see: http://www.squid-cache.org/Doc/config/forwarded_for/

seems to work for me, please consider to merge it. thanks.