### PR TITLE
Add missing package state values

### DIFF
--- a/types/pkgensure.pp
+++ b/types/pkgensure.pp
@@ -1,4 +1,4 @@
 type Squid::PkgEnsure = Variant[
   Pattern[/^\d.*/],
-  Enum['present', 'latest', 'absent', 'purged'],
+  Enum['present', 'latest', 'absent', 'purged', 'held', 'installed'],
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds the `held` and `installed` values to `Squid::PkgEnsure` validation to allow all values supported by Puppet (https://puppet.com/docs/puppet/latest/types/package.html#package-attribute-ensure).

This is useful if you need to hold the version of Squid installed, for example if you have needed to manually build the package on Debian for SSL support. 

#### This Pull Request (PR) fixes the following issues
n/a
