### PR TITLE
add typedef and class documentation

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -1,3 +1,22 @@
+# @summary 
+#   Defines acl entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/acl/
+# @example create an ACL 'remote_urls' containing two entries
+#   squid::acl { 'remote_urls':
+#      type    => 'url_regex',
+#      entries => ['http://example.org/path',
+#                  'http://example.com/anotherpath'],
+#   }
+#
+# @param [String] type 
+#   The acltype of the acl, must be defined, e.g url_regex, urlpath_regex, port, ..
+# @param [String] aclname 
+#   The name of acl, defaults to the `title`.
+# @param [Array] entries 
+#   An array of acl entries, multiple members results in multiple lines in squid.conf.
+# @param [String] order 
+#   Each ACL has an order `05` by default this can be specified if order of ACL definition matters.
 define squid::acl (
   String $type,
   String $aclname = $title,

--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -9,13 +9,13 @@
 #                  'http://example.com/anotherpath'],
 #   }
 #
-# @param [String] type 
+# @param type 
 #   The acltype of the acl, must be defined, e.g url_regex, urlpath_regex, port, ..
-# @param [String] aclname 
+# @param aclname 
 #   The name of acl, defaults to the `title`.
-# @param [Array] entries 
+# @param entries 
 #   An array of acl entries, multiple members results in multiple lines in squid.conf.
-# @param [String] order 
+# @param order 
 #   Each ACL has an order `05` by default this can be specified if order of ACL definition matters.
 define squid::acl (
   String $type,

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -1,3 +1,29 @@
+# @summary 
+#   Defines auth_param entries  for a squid server.
+# @see 
+#   http://www.squid-cache.org/Doc/config/auth_param/ 
+# @example
+#   squid::auth_param { 'basic auth_param':
+#     scheme  => 'basic',
+#     entries => [
+#       'program /usr/lib64/squid/basic_ncsa_auth /etc/squid/.htpasswd',
+#       'children 5',
+#       'realm Squid Basic Authentication',
+#       'credentialsttl 5 hours',
+#     ],
+#   }
+#   would result in multi entry squid auth_param:
+#   auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/.htpasswd
+#   auth_param basic children 5
+#   auth_param basic realm Squid Basic Authentication
+#   auth_param basic credentialsttl 5 hours
+# 
+# @param [Enum['basic', 'digest', 'negotiate', 'ntlm']] scheme 
+#   The scheme used for authentication must be defined. Valid values are 'basic', 'digest', 'negotiate' and 'ntlm'.
+# @param [Array] entries 
+#   An array of entries, multiple members results in multiple lines in squid.conf
+# @param [String] order 
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::auth_param (
   Enum['basic', 'digest', 'negotiate', 'ntlm']
           $scheme,

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -18,11 +18,11 @@
 #   auth_param basic realm Squid Basic Authentication
 #   auth_param basic credentialsttl 5 hours
 # 
-# @param [Enum['basic', 'digest', 'negotiate', 'ntlm']] scheme 
+# @param scheme 
 #   The scheme used for authentication must be defined. Valid values are 'basic', 'digest', 'negotiate' and 'ntlm'.
-# @param [Array] entries 
+# @param entries 
 #   An array of entries, multiple members results in multiple lines in squid.conf
-# @param [String] order 
+# @param order 
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::auth_param (
   Enum['basic', 'digest', 'negotiate', 'ntlm']

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -11,11 +11,11 @@
 #   Adds a squid.conf line:
 #   #Our networks hosts denied for caching
 #   cache deny our_network_hosts_acl
-# @param [Enum['allow', 'deny']] action
+# @param action
 #   Allow/deny caching for $title
-# @param [String] comment
+# @param comment
 #   Cache entry's preceding comment
-# @param [String]  order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::cache (
   Enum['allow', 'deny']

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -1,3 +1,22 @@
+# @summary 
+#   Defines cache entries  for a squid server.
+# @see 
+#   http://www.squid-cache.org/Doc/config/cache/
+# @example
+#   squid::cache { 'our_network_hosts_acl':
+#     action    => 'deny',
+#     comment   => 'Our networks hosts are denied for caching',
+#   }
+#
+#   Adds a squid.conf line:
+#   #Our networks hosts denied for caching
+#   cache deny our_network_hosts_acl
+# @param [Enum['allow', 'deny']] action
+#   Allow/deny caching for $title
+# @param [String] comment
+#   Cache entry's preceding comment
+# @param [String]  order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::cache (
   Enum['allow', 'deny']
           $action  = 'allow',

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -1,3 +1,35 @@
+# @summary 
+#   Defines cache_dir entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/cache_dir/ 
+# @example
+#   squid::cache_dir { '/data':
+#     type           => 'ufs',
+#     options        => '15000 32 256 min-size=32769',
+#     process_number => 2,
+#   }
+#   Results in the squid configuration of
+#
+#   if ${processor} = 2
+#   cache_dir ufs 15000 32 256 min-size=32769
+#   endif
+#
+# @param [String] type 
+#   The type of cache, e.g ufs. defaults to `ufs`.
+# @param [String] path 
+#   Defaults to the namevar, file path to  cache.
+# @param [String] options 
+#   String of options for the cache. Defaults to empty string.
+# @option [Integer] process_number 
+#   If specfied as an integer the cache will be wrapped
+#   in a `if $proceess_number` statement so the cache will be used by only
+#   one process. Default is undef.
+# @param [Boolean] manage_dir [Boolean] 
+#   If true puppet will attempt to create the
+#   directory, if false you will have to create it yourself. Make sure the
+#   directory has the correct owner, group and mode. Defaults to true.
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::cache_dir (
   String            $type           = ufs,
   String            $path           = $title,

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -14,21 +14,21 @@
 #   cache_dir ufs 15000 32 256 min-size=32769
 #   endif
 #
-# @param [String] type 
+# @param type 
 #   The type of cache, e.g ufs. defaults to `ufs`.
-# @param [String] path 
+# @param path 
 #   Defaults to the namevar, file path to  cache.
-# @param [String] options 
+# @param options 
 #   String of options for the cache. Defaults to empty string.
-# @option [Integer] process_number 
+# @param process_number 
 #   If specfied as an integer the cache will be wrapped
 #   in a `if $proceess_number` statement so the cache will be used by only
 #   one process. Default is undef.
-# @param [Boolean] manage_dir [Boolean] 
+# @param manage_dir 
 #   If true puppet will attempt to create the
 #   directory, if false you will have to create it yourself. Make sure the
 #   directory has the correct owner, group and mode. Defaults to true.
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::cache_dir (
   String            $type           = ufs,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,8 @@
 #   Configure the system to use squid
 #   config is included in the main class `squid`
 #   for parameters see `squid` class
+# @api
+#   private
 class squid::config (
   $config                        = $squid::config,
   $config_user                   = $squid::config_user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,3 +1,7 @@
+# @summary
+#   Configure the system to use squid
+#   config is included in the main class `squid`
+#   for parameters see `squid` class
 class squid::config (
   $config                        = $squid::config,
   $config_user                   = $squid::config_user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,8 +2,7 @@
 #   Configure the system to use squid
 #   config is included in the main class `squid`
 #   for parameters see `squid` class
-# @api
-#   private
+# @api private
 class squid::config (
   $config                        = $squid::config,
   $config_user                   = $squid::config_user,

--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -47,12 +47,12 @@
 #   always_direct allow   my-good-dst
 #   always_direct allow   my-other-good-dst
 # 
-# @param [String] comment 
+# @param comment 
 #   Defaults to the namevar and is used as a section comment in `squid.conf`.
-# @param [Variant[Array,Hash]] config_entries 
+# @param config_entries 
 #   A hash of configuration entries to create in this section.  The hash key is the name of the configuration directive.  
 #   The value is either a string, or an array of strings to use as the configuration directive options.
-# @param [String] order 
+# @param order 
 #   Order can be used to configure where in `squid.conf` this configuration section should occur.
 define squid::extra_config_section (
   String              $comment = $title,

--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -1,3 +1,59 @@
+# @summary 
+#   The `extra_config_section` defiend type can be used for configuration directives that have not been exposed individually in this module.
+# 
+# @example Using a hash of config_entries:
+#   squid::extra_config_section { 'mail settings':
+#     order          => '60',
+#     config_entries => {
+#       'mail_from'    => 'squid@example.com',
+#       'mail_program' => 'mail',
+#     },
+#   }
+# 
+#   Results in a squid configuration of
+#   # mail settings
+#   mail_from squid@example.com
+#   mail_program mail
+# 
+# @example Using an array of config_entries:
+#   squid::extra_config_section { 'ssl_bump settings':
+#     order          => '60',
+#     config_entries => {
+#       'ssl_bump'         => ['server-first', 'all'],
+#       'sslcrtd_program'  => ['/usr/lib64/squid/ssl_crtd', '-s', '/var/lib/ssl_db', '-M', '4MB'],
+#       'sslcrtd_children' => ['8', 'startup=1', 'idle=1'],
+#     }
+#   }
+# 
+#   Results in a squid configuration of:
+#   # ssl_bump settings
+#   ssl_bump server-first all
+#   sslcrtd_program /usr/lib64/squid/ssl_crtd -s /var/lib/ssl_db -M 4MB
+#   sslcrtd_children 8 startup=1 idle=1
+# 
+# @example Using an array of hashes of config_entries:
+#   squid::extra_config_section { 'always_directs':
+#     order          => '60',
+#     config_entries => [{
+#       'always_direct' => ['deny    www.reallyreallybadplace.com',
+#                           'allow   my-good-dst',
+#                           'allow   my-other-good-dst'],
+#     }],
+#   }
+# 
+#   Results in a squid configuration of
+#   # always_directs
+#   always_direct deny    www.reallyreallybadplace.com
+#   always_direct allow   my-good-dst
+#   always_direct allow   my-other-good-dst
+# 
+# @param [String] comment 
+#   Defaults to the namevar and is used as a section comment in `squid.conf`.
+# @param [Variant[Array,Hash]] config_entries 
+#   A hash of configuration entries to create in this section.  The hash key is the name of the configuration directive.  
+#   The value is either a string, or an array of strings to use as the configuration directive options.
+# @param [String] order 
+#   Order can be used to configure where in `squid.conf` this configuration section should occur.
 define squid::extra_config_section (
   String              $comment = $title,
   Variant[Array,Hash] $config_entries = {},

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -20,13 +20,13 @@
 #   Adds a squid.conf line
 #   # Our networks hosts are allowed
 #   http_access allow our_networks hosts
-# @param [String] title
+# @param title
 #   The name of the ACL the rule is applied to
-# @param [Enum['allow', 'deny']] action
+# @param action
 #   allow or deny access for $title
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
-# @param [String] comment
+# @param comment
 #   http_access entry's preceding comment
 define squid::http_access (
   Enum['allow', 'deny']

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -1,3 +1,33 @@
+# @summary 
+#   Defines http_access entries for a squid server.
+# @see 
+#   https://github.com/puppetlabs/puppetlabs-docker/blob/master/REFERENCE.md
+# @example
+#   squid::http_access { 'our_networks hosts':
+#     action => 'allow',
+#   }
+# 
+#   Adds a squid.conf line
+#   # http_access fragment for out_networks hosts
+#   http_access allow our_networks hosts
+# 
+# @example
+#   squid::http_access { 'our_networks hosts':
+#     action    => 'allow',
+#     comment   => 'Our networks hosts are allowed',
+#   }
+#
+#   Adds a squid.conf line
+#   # Our networks hosts are allowed
+#   http_access allow our_networks hosts
+# @param [String] title
+#   The name of the ACL the rule is applied to
+# @param [Enum['allow', 'deny']] action
+#   allow or deny access for $title
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
+# @param [String] comment
+#   http_access entry's preceding comment
 define squid::http_access (
   Enum['allow', 'deny']
           $action  = 'allow',

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -21,9 +21,9 @@
 # @param title
 #   The title/namevar may be in the form `port` or `host:port` to provide the below values. Otherwise,
 #   specify `port` explicitly, and `host` if desired.
-# @option port 
+# @param port 
 #   Defaults to the port of the namevar and is the port number to listen on.
-# @option host 
+# @param host 
 #   Defaults to the host part of the namevar and is the interface to listen on. If not specified, Squid listens on all interfaces.
 # @param options 
 #   A string to specify any options for the default. By default and empty string.

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -18,18 +18,18 @@
 #   http_port 10000 accel vhost
 #   https_port 10001 cert=/etc/squid/ssl_cert/server.cert key=/etc/squid/ssl_cert/server.key
 #   http_port 127.0.0.1:3128
-# @param [String] title
+# @param title
 #   The title/namevar may be in the form `port` or `host:port` to provide the below values. Otherwise,
 #   specify `port` explicitly, and `host` if desired.
-# @option [Stdlib::Port] port 
+# @option port 
 #   Defaults to the port of the namevar and is the port number to listen on.
-# @option [Stdlib::Host] host 
+# @option host 
 #   Defaults to the host part of the namevar and is the interface to listen on. If not specified, Squid listens on all interfaces.
-# @param [String] options 
+# @param options 
 #   A string to specify any options for the default. By default and empty string.
-# @param [Boolean] ssl 
+# @param ssl 
 #   When set to `true` creates https_port entries. Defaults to `false`.
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::http_port (
   Optional[Stdlib::Port] $port    = undef,

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -1,3 +1,36 @@
+# @summary
+#   Defines http_port entries for a squid server.
+#   By setting optional `ssl` parameter to `true` will create https_port entries instead.
+# @see
+#   http://www.squid-cache.org/Doc/config/http_port/
+# @example
+#   squid::http_port { '10000':
+#     options => 'accel vhost'
+#   }
+#   squid::http_port { '10001':
+#     ssl     => true,
+#     options => 'cert=/etc/squid/ssl_cert/server.cert key=/etc/squid/ssl_cert/server.key'
+#   }
+#   squid::http_port { '127.0.0.1:3128':
+#   }
+#
+#   Results in a squid configuration of:
+#   http_port 10000 accel vhost
+#   https_port 10001 cert=/etc/squid/ssl_cert/server.cert key=/etc/squid/ssl_cert/server.key
+#   http_port 127.0.0.1:3128
+# @param [String] title
+#   The title/namevar may be in the form `port` or `host:port` to provide the below values. Otherwise,
+#   specify `port` explicitly, and `host` if desired.
+# @option [Stdlib::Port] port 
+#   Defaults to the port of the namevar and is the port number to listen on.
+# @option [Stdlib::Host] host 
+#   Defaults to the host part of the namevar and is the interface to listen on. If not specified, Squid listens on all interfaces.
+# @param [String] options 
+#   A string to specify any options for the default. By default and empty string.
+# @param [Boolean] ssl 
+#   When set to `true` creates https_port entries. Defaults to `false`.
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::http_port (
   Optional[Stdlib::Port] $port    = undef,
   Optional[Stdlib::Host] $host    = undef,

--- a/manifests/https_port.pp
+++ b/manifests/https_port.pp
@@ -1,3 +1,13 @@
+# @summary 
+#   Defines https_port entries for a squid server. Results are the same with http_port and ssl set to `true`.
+# @see 
+#   http://www.squid-cache.org/Doc/config/https_port/
+# @param [Variant[Pattern[/\d+/], Integer]] port 
+#   defaults to the namevar and is the port number.
+# @param [String] options 
+#   A string to specify any options to add to the https_port line.  Defaults to an empty string.
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::https_port (
   Variant[Pattern[/\d+/], Integer]
           $port    = $title,

--- a/manifests/https_port.pp
+++ b/manifests/https_port.pp
@@ -2,11 +2,11 @@
 #   Defines https_port entries for a squid server. Results are the same with http_port and ssl set to `true`.
 # @see 
 #   http://www.squid-cache.org/Doc/config/https_port/
-# @param [Variant[Pattern[/\d+/], Integer]] port 
+# @param port 
 #   defaults to the namevar and is the port number.
-# @param [String] options 
+# @param options 
 #   A string to specify any options to add to the https_port line.  Defaults to an empty string.
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::https_port (
   Variant[Pattern[/\d+/], Integer]

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -9,10 +9,10 @@
 #   Adds a squid.conf line
 #   icp_access allow our_networks hosts
 #
-# @param [Enum['allow', 'deny']] action 
+# @param action 
 #   Must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
 #   all allows appear before all denys. This can be overidden with the `order` parameter.
-# @param [String] order 
+# @param order 
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 >>>>>>> ff51a3b000f7304712a571f86cce0fa33ac5ce31
 define squid::icp_access (

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -14,7 +14,6 @@
 #   all allows appear before all denys. This can be overidden with the `order` parameter.
 # @param order 
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
->>>>>>> ff51a3b000f7304712a571f86cce0fa33ac5ce31
 define squid::icp_access (
   Enum['allow', 'deny']
           $action = 'allow',

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -1,3 +1,19 @@
+# @summary 
+#   Defines icp_access entries for a squid server.
+# @see http://www.squid-cache.org/Doc/config/icp_access/
+# @example
+#   squid::icp_access { 'our_networks hosts':
+#     action => 'allow',
+#   }
+#
+#   Adds a squid.conf line
+#   icp_access allow our_networks hosts
+#
+# @param [Enum['allow', 'deny']] action 
+#   Must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
+#   all allows appear before all denys. This can be overidden with the `order` parameter.
+# @param [String] order 
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::icp_access (
   Enum['allow', 'deny']
           $action = 'allow',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,27 +31,27 @@
 #   Group which runs the squid daemon, this is used for ownership of the cache directory, default depends on `$operatingsystem`
 # @param cache_mem 
 #   Defaults to `256 MB`. http://www.squid-cache.org/Doc/config/cache_mem/
-# @option cache_replacement_policy 
+# @param cache_replacement_policy 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/cache_replacement_policy/
-# @option memory_replacement_policy 
+# @param memory_replacement_policy 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_replacement_policy/
-# @option memory_cache_shared 
+# @param memory_cache_shared 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_cache_shared/.
 # @param maximum_object_size_in_memory 
 #   Defaults to `512 KB`. http://www.squid-cache.org/Doc/config/maximum_object_size_in_memory/
-# @option url_rewrite_program 
+# @param url_rewrite_program 
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_program/
-# @option url_rewrite_children 
+# @param url_rewrite_children 
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
-# @option url_rewrite_child_options 
+# @param url_rewrite_child_options 
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
 # @param access_log 
 #   Defaults to `daemon:/var/logs/squid/access.log squid`. http://www.squid-cache.org/Doc/config/access_log/
-# @option coredump_dir 
+# @param coredump_dir 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/coredump_dir/
-# @option error_directory 
+# @param error_directory 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/error_directory/
-# @option err_page_stylesheet 
+# @param err_page_stylesheet 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/err_page_stylesheet/
 # @param package_name 
 #   Name of the squid package to manage, default depends on `$operatingsystem`
@@ -59,47 +59,47 @@
 #   Package status and/or version, default to present
 # @param service_name 
 #   Name of the squid service to manage, default depends on `$operatingsystem`
-# @option max_filedescriptors 
+# @param max_filedescriptors 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/max_filedescriptors/
-# @option workers 
+# @param workers 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/workers/
-# @option snmp_incoming_address 
+# @param snmp_incoming_address 
 #   Defaults to undef. Can be set to an IP address to only listen for snmp requests on an individual interface. http://www.squid-cache.org/Doc/config/snmp_incoming_address/
-# @option buffered_logs 
+# @param buffered_logs 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/buffered_logs/
-# @option acls 
+# @param acls 
 #   Defaults to undef. If you pass in a hash of acl entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/acl/
-# @option visible_hostname 
+# @param visible_hostname 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/visible_hostname/
-# @option via 
+# @param via 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/via/
-# @option httpd_suppress_version_string 
+# @param httpd_suppress_version_string 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/httpd_suppress_version_string/
-# @option forwarded_for 
+# @param forwarded_for 
 #   Defaults to undef. supported values are "on", "off", "transparent", "delete", "truncate". http://www.squid-cache.org/Doc/config/forwarded_for/
-# @option http_access 
+# @param http_access 
 #   Defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_access/
-# @option http_ports 
+# @param http_ports 
 #   Defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_port/
-# @option https_ports 
+# @param https_ports 
 #   Defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/https_port/
-# @option icp_access 
+# @param icp_access 
 #   Defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/icp_access/
-# @option refresh_patterns 
+# @param refresh_patterns 
 #   Defaults to undef.  If you pass a hash of refresh_pattern entires, they will be defined automatically. http://www.squid-cache.org/Doc/config/refresh_pattern/
-# @option snmp_ports 
+# @param snmp_ports 
 #   Defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/snmp_port/
-# @option send_hit 
+# @param send_hit 
 #   Defaults to undef. If you pass in a hash of send_hit entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/send_hit/
-# @option cache_dirs 
+# @param cache_dirs 
 #   Defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/cache_dir/
-# @option ssl_bump 
+# @param ssl_bump 
 #   Defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/ssl_bump/
-# @option sslproxy_cert_error 
+# @param sslproxy_cert_error 
 #   Defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/sslproxy_cert_error/
-# @option extra_config_sections 
+# @param extra_config_sections 
 #   Defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
-# @option service_restart 
+# @param service_restart 
 #   Defaults to undef. Overrides service resource restart command to be executed. 
 #   It can be used to perform a soft reload of the squid service.
 # @param squid_bin_path 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,94 +15,94 @@
 #     action => deny,
 #   }
 # 
-# @param [String] ensure_service 
+# @param ensure_service 
 #   The ensure value of the squid service, defaults to `running`.
-# @param [Boolean] enable_service 
+# @param enable_service 
 #   The enable value of the squid service, defaults to `true`.
-# @param [String] config 
+# @param config 
 #   Location of squid.conf file, defaults to `/etc/squid/squid.conf`.
-# @param [String] config_user 
+# @param config_user 
 #   User which owns the config file, default depends on `$operatingsystem`
-# @param [String] config_group 
+# @param config_group 
 #   Group which owns the config file, default depends on `$operatingsystem`
-# @param [String] daemon_user 
+# @param daemon_user 
 #   User which runs the squid daemon, this is used for ownership of the cache directory, default depends on `$operatingsystem`
-# @param [String] daemon_group 
+# @param daemon_group 
 #   Group which runs the squid daemon, this is used for ownership of the cache directory, default depends on `$operatingsystem`
-# @param [Squid::Size] cache_mem 
+# @param cache_mem 
 #   Defaults to `256 MB`. http://www.squid-cache.org/Doc/config/cache_mem/
-# @option [String] cache_replacement_policy 
+# @option cache_replacement_policy 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/cache_replacement_policy/
-# @option [String] memory_replacement_policy 
+# @option memory_replacement_policy 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_replacement_policy/
-# @option [Variant[Enum['on', 'off'], Boolean]] memory_cache_shared 
+# @option memory_cache_shared 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_cache_shared/.
-# @param [Squid::Size] maximum_object_size_in_memory 
+# @param maximum_object_size_in_memory 
 #   Defaults to `512 KB`. http://www.squid-cache.org/Doc/config/maximum_object_size_in_memory/
-# @option [String] url_rewrite_program 
+# @option url_rewrite_program 
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_program/
-# @option [Integer] url_rewrite_children 
+# @option url_rewrite_children 
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
-# @option [String] url_rewrite_child_options 
+# @option url_rewrite_child_options 
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
-# @param [String] access_log 
+# @param access_log 
 #   Defaults to `daemon:/var/logs/squid/access.log squid`. http://www.squid-cache.org/Doc/config/access_log/
-# @option [String] coredump_dir 
+# @option coredump_dir 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/coredump_dir/
-# @option [Stdlib::Absolutepath] error_directory 
+# @option error_directory 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/error_directory/
-# @option [Stdlib::Absolutepath] err_page_stylesheet 
+# @option err_page_stylesheet 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/err_page_stylesheet/
-# @param [String] package_name 
+# @param package_name 
 #   Name of the squid package to manage, default depends on `$operatingsystem`
-# @param [Squid::PkgEnsure] package_ensure 
+# @param package_ensure 
 #   Package status and/or version, default to present
-# @param [String] service_name 
+# @param service_name 
 #   Name of the squid service to manage, default depends on `$operatingsystem`
-# @option [Integer] max_filedescriptors 
+# @option max_filedescriptors 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/max_filedescriptors/
-# @option [Integer] workers 
+# @option workers 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/workers/
-# @option [Stdlib::Compat::Ip_address] snmp_incoming_address 
+# @option snmp_incoming_address 
 #   Defaults to undef. Can be set to an IP address to only listen for snmp requests on an individual interface. http://www.squid-cache.org/Doc/config/snmp_incoming_address/
-# @option [Boolean] buffered_logs 
+# @option buffered_logs 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/buffered_logs/
-# @option [Hash] acls 
+# @option acls 
 #   Defaults to undef. If you pass in a hash of acl entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/acl/
-# @option [String] visible_hostname 
+# @option visible_hostname 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/visible_hostname/
-# @option [Boolean] via 
+# @option via 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/via/
-# @option [Boolean] httpd_suppress_version_string 
+# @option httpd_suppress_version_string 
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/httpd_suppress_version_string/
-# @option [Variant[Enum['on', 'off', 'transparent', 'delete', 'truncate'], Boolean]] forwarded_for 
+# @option forwarded_for 
 #   Defaults to undef. supported values are "on", "off", "transparent", "delete", "truncate". http://www.squid-cache.org/Doc/config/forwarded_for/
-# @option [Hash] http_access 
+# @option http_access 
 #   Defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_access/
-# @option [Hash] http_ports 
+# @option http_ports 
 #   Defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_port/
-# @option [Hash] https_ports 
+# @option https_ports 
 #   Defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/https_port/
-# @option [Hash] icp_access 
+# @option icp_access 
 #   Defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/icp_access/
-# @option [Hash] refresh_patterns 
+# @option refresh_patterns 
 #   Defaults to undef.  If you pass a hash of refresh_pattern entires, they will be defined automatically. http://www.squid-cache.org/Doc/config/refresh_pattern/
-# @option [Hash] snmp_ports 
+# @option snmp_ports 
 #   Defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/snmp_port/
-# @option [Hash] send_hit 
+# @option send_hit 
 #   Defaults to undef. If you pass in a hash of send_hit entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/send_hit/
-# @option [Hash] cache_dirs 
+# @option cache_dirs 
 #   Defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/cache_dir/
-# @option [Hash] ssl_bump 
+# @option ssl_bump 
 #   Defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/ssl_bump/
-# @option [Hash] sslproxy_cert_error 
+# @option sslproxy_cert_error 
 #   Defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/sslproxy_cert_error/
-# @option [Hash] extra_config_sections 
+# @option extra_config_sections 
 #   Defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
-# @option [String] service_restart 
+# @option service_restart 
 #   Defaults to undef. Overrides service resource restart command to be executed. 
 #   It can be used to perform a soft reload of the squid service.
-# @param [Stdlib::Absolutepath] squid_bin_path 
+# @param squid_bin_path 
 #   Path to the squid binary, default depends on `$operatingsystem`
 # @example
 #   class { 'squid':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,135 @@
+# @summary 
+#   Module for configuring the squid caching service. 
+#   The module will set the SELINUX-context for the cache_dir and port, needs puppet-selinux
+#
+# @example The set up a simple squid server with a cache to forward http port 80 requests.
+#   class { 'squid': }
+#   squid::acl { 'Safe_ports':
+#     type    => port,
+#     entries => ['80'],
+#   }
+#   squid::http_access { 'Safe_ports':
+#     action => allow,
+#   }
+#   squid::http_access{ '!Safe_ports':
+#     action => deny,
+#   }
+# 
+# @param [String] ensure_service 
+#   The ensure value of the squid service, defaults to `running`.
+# @param [Boolean] enable_service 
+#   The enable value of the squid service, defaults to `true`.
+# @param [String] config 
+#   Location of squid.conf file, defaults to `/etc/squid/squid.conf`.
+# @param [String] config_user 
+#   User which owns the config file, default depends on `$operatingsystem`
+# @param [String] config_group 
+#   Group which owns the config file, default depends on `$operatingsystem`
+# @param [String] daemon_user 
+#   User which runs the squid daemon, this is used for ownership of the cache directory, default depends on `$operatingsystem`
+# @param [String] daemon_group 
+#   Group which runs the squid daemon, this is used for ownership of the cache directory, default depends on `$operatingsystem`
+# @param [Squid::Size] cache_mem 
+#   Defaults to `256 MB`. http://www.squid-cache.org/Doc/config/cache_mem/
+# @option [String] cache_replacement_policy 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/cache_replacement_policy/
+# @option [String] memory_replacement_policy 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_replacement_policy/
+# @option [Variant[Enum['on', 'off'], Boolean]] memory_cache_shared 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_cache_shared/.
+# @param [Squid::Size] maximum_object_size_in_memory 
+#   Defaults to `512 KB`. http://www.squid-cache.org/Doc/config/maximum_object_size_in_memory/
+# @option [String] url_rewrite_program 
+#   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_program/
+# @option [Integer] url_rewrite_children 
+#   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
+# @option [String] url_rewrite_child_options 
+#   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
+# @param [String] access_log 
+#   Defaults to `daemon:/var/logs/squid/access.log squid`. http://www.squid-cache.org/Doc/config/access_log/
+# @option [String] coredump_dir 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/coredump_dir/
+# @option [Stdlib::Absolutepath] error_directory 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/error_directory/
+# @option [Stdlib::Absolutepath] err_page_stylesheet 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/err_page_stylesheet/
+# @param [String] package_name 
+#   Name of the squid package to manage, default depends on `$operatingsystem`
+# @param [Squid::PkgEnsure] package_ensure 
+#   Package status and/or version, default to present
+# @param [String] service_name 
+#   Name of the squid service to manage, default depends on `$operatingsystem`
+# @option [Integer] max_filedescriptors 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/max_filedescriptors/
+# @option [Integer] workers 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/workers/
+# @option [Stdlib::Compat::Ip_address] snmp_incoming_address 
+#   Defaults to undef. Can be set to an IP address to only listen for snmp requests on an individual interface. http://www.squid-cache.org/Doc/config/snmp_incoming_address/
+# @option [Boolean] buffered_logs 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/buffered_logs/
+# @option [Hash] acls 
+#   Defaults to undef. If you pass in a hash of acl entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/acl/
+# @option [String] visible_hostname 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/visible_hostname/
+# @option [Boolean] via 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/via/
+# @option [Boolean] httpd_suppress_version_string 
+#   Defaults to undef. http://www.squid-cache.org/Doc/config/httpd_suppress_version_string/
+# @option [Variant[Enum['on', 'off', 'transparent', 'delete', 'truncate'], Boolean]] forwarded_for 
+#   Defaults to undef. supported values are "on", "off", "transparent", "delete", "truncate". http://www.squid-cache.org/Doc/config/forwarded_for/
+# @option [Hash] http_access 
+#   Defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_access/
+# @option [Hash] http_ports 
+#   Defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_port/
+# @option [Hash] https_ports 
+#   Defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/https_port/
+# @option [Hash] icp_access 
+#   Defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/icp_access/
+# @option [Hash] refresh_patterns 
+#   Defaults to undef.  If you pass a hash of refresh_pattern entires, they will be defined automatically. http://www.squid-cache.org/Doc/config/refresh_pattern/
+# @option [Hash] snmp_ports 
+#   Defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/snmp_port/
+# @option [Hash] send_hit 
+#   Defaults to undef. If you pass in a hash of send_hit entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/send_hit/
+# @option [Hash] cache_dirs 
+#   Defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/cache_dir/
+# @option [Hash] ssl_bump 
+#   Defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/ssl_bump/
+# @option [Hash] sslproxy_cert_error 
+#   Defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/sslproxy_cert_error/
+# @option [Hash] extra_config_sections 
+#   Defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
+# @option [String] service_restart 
+#   Defaults to undef. Overrides service resource restart command to be executed. 
+#   It can be used to perform a soft reload of the squid service.
+# @param [Stdlib::Absolutepath] squid_bin_path 
+#   Path to the squid binary, default depends on `$operatingsystem`
+# @example
+#   class { 'squid':
+#     cache_mem    => '512 MB',
+#     workers      => 3,
+#     coredump_dir => '/var/spool/squid',
+#   }
+# 
+# @example
+#   class { 'squid':
+#     cache_mem                 => '512 MB',
+#     workers                   => 3,
+#     coredump_dir              => '/var/spool/squid',
+#     acls                      => { 'remote_urls' => {
+#                                      type    => 'url_regex',
+#                                      entries => ['http://example.org/path',
+#                                                  'http://example.com/anotherpath'],
+#                                    },
+#                                  },
+#     http_access               => { 'our_networks hosts' => { action => 'allow', }},
+#     http_ports                => { '10000' => { options => 'accel vhost', }},
+#     snmp_ports                => { '1000' => { process_number => 3, }},
+#     cache_dirs                => { '/data/' => { type => 'ufs', options => '15000 32 256 min-size=32769', process_number => 2 }},
+#     url_rewrite_program       => '/usr/bin/squidguard -c /etc/squidguard/squidguard.conf',
+#     url_rewrite_children      => 12,
+#     url_rewrite_child_options => startup=1,
+#   }
 class squid (
   String            $access_log                       = $squid::params::access_log,
   Squid::Size       $cache_mem                        = $squid::params::cache_mem,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,6 @@
 # @summary
 #   Installs the squid package
-# @api
-#   private
+# @api private
 class squid::install  {
 
   package{$squid::package_name:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,5 @@
-# Class: squid::install
-
+# @summary
+#   Installs the squid package
 class squid::install  {
 
   package{$squid::package_name:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,7 @@
 # @summary
 #   Installs the squid package
+# @api
+#   private
 class squid::install  {
 
   package{$squid::package_name:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,7 @@
 # @summary 
 #   This class manages Squid parameters
+# @api
+#   private
 class squid::params {
 
   $ensure_service                = 'running'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,5 @@
-# Class: squid::params
-#
-# This class manages Squid parameters
-
+# @summary 
+#   This class manages Squid parameters
 class squid::params {
 
   $ensure_service                = 'running'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,6 @@
 # @summary 
 #   This class manages Squid parameters
-# @api
-#   private
+# @api private
 class squid::params {
 
   $ensure_service                = 'running'

--- a/manifests/refresh_pattern.pp
+++ b/manifests/refresh_pattern.pp
@@ -1,3 +1,67 @@
+# @summary
+#   Defines refresh_pattern entries for a squid server.
+# @see http://www.squid-cache.org/Doc/config/refresh_pattern/
+# @example
+#   squid::refresh_pattern { '^ftp:':
+#     min     => 1440,
+#     max     => 10080,
+#     percent => 20,
+#     order   => 60,
+#   }
+#
+#   squid::refresh_pattern { '(/cgi-bin/|\?)':
+#     case_sensitive => false,
+#     min            => 0,
+#     max            => 0,
+#     percent        => 0,
+#     order          => 61,
+#   }
+#
+#   would result in the following squid refresh patterns:
+#   # refresh_pattern fragment for ^ftp
+#   refresh_pattern ^ftp: 1440 20% 10080
+#   # refresh_pattern fragment for (/cgi-bin/|\?)
+#   refresh_pattern (/cgi-bin/|\?) -i 0 0% 0
+#
+# 
+# @example YAML example
+#   squid::refresh_patterns:
+#     '^ftp':
+#       max:     10080
+#       min:     1440
+#       percent: 20
+#       order:   '60'
+#     '^gopher':
+#       max:     1440
+#       min:     1440
+#       percent: 0
+#       order:   '61'
+#     '(/cgi-bin/|\?)':
+#       case_sensitive: false
+#       max:            0
+#       min:            0
+#       percent:        0
+#       order:          '62'
+#     '.':
+#       max:     4320
+#       min:     0
+#       percent: 20
+#       order:   '63'
+#
+# @param [Boolean] case_sensitive 
+#   If true (default) the regex is case sensitive, when false the case insensitive flag '-i' is added to the pattern
+# @param [String] comment 
+#   Comment added before refresh rule, defaults to refresh_pattern fragment for `title`
+# @param [Integer] min 
+#   Must be defined, the time (in minutes) an object without an explicit expiry time should be considered fresh.
+# @param [Integer] max 
+#   Must be defined, the upper limit (in minutes) on how long objects without an explicit expiry time will be considered fresh.
+# @param [Integer] percent 
+#   Must be defined, is a percentage of the objects age (time since last modification age)
+# @param [String] options 
+#   See squid documentation for available options.
+# @param [String] order 
+#   Each refresh_pattern has an order `05` by default this can be specified if order of refresh_pattern definition matters.
 define squid::refresh_pattern (
   Integer $max,
   Integer $min,

--- a/manifests/refresh_pattern.pp
+++ b/manifests/refresh_pattern.pp
@@ -48,19 +48,19 @@
 #       percent: 20
 #       order:   '63'
 #
-# @param [Boolean] case_sensitive 
+# @param case_sensitive 
 #   If true (default) the regex is case sensitive, when false the case insensitive flag '-i' is added to the pattern
-# @param [String] comment 
+# @param comment 
 #   Comment added before refresh rule, defaults to refresh_pattern fragment for `title`
-# @param [Integer] min 
+# @param min 
 #   Must be defined, the time (in minutes) an object without an explicit expiry time should be considered fresh.
-# @param [Integer] max 
+# @param max 
 #   Must be defined, the upper limit (in minutes) on how long objects without an explicit expiry time will be considered fresh.
-# @param [Integer] percent 
+# @param percent 
 #   Must be defined, is a percentage of the objects age (time since last modification age)
-# @param [String] options 
+# @param options 
 #   See squid documentation for available options.
-# @param [String] order 
+# @param order 
 #   Each refresh_pattern has an order `05` by default this can be specified if order of refresh_pattern definition matters.
 define squid::refresh_pattern (
   Integer $max,

--- a/manifests/send_hit.pp
+++ b/manifests/send_hit.pp
@@ -10,13 +10,13 @@
 #   Adds the following squid.conf line:
 #   send_hit deny PragmaNoCache
 #
-# @param [String] value 
+# @param value 
 #   Defaults to the `namevar`. The rule to allow or deny.
-# @param [Enum['allow', 'deny']] action 
+# @param action 
 #   Must one of `deny` or `allow`
-# @param [String] order 
+# @param order 
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
-# @param [String] comment 
+# @param comment 
 #   A preceeding comment to add to the configuration file.
 define squid::send_hit (
   Enum['allow', 'deny']

--- a/manifests/send_hit.pp
+++ b/manifests/send_hit.pp
@@ -1,3 +1,23 @@
+# @summary 
+#   Defines send_hit for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/send_hit/
+# @example
+#   squid:::send_hit{'PragmaNoCache':
+#     action => 'deny',
+#   }
+#
+#   Adds the following squid.conf line:
+#   send_hit deny PragmaNoCache
+#
+# @param [String] value 
+#   Defaults to the `namevar`. The rule to allow or deny.
+# @param [Enum['allow', 'deny']] action 
+#   Must one of `deny` or `allow`
+# @param [String] order 
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
+# @param [String] comment 
+#   A preceeding comment to add to the configuration file.
 define squid::send_hit (
   Enum['allow', 'deny']
           $action  = 'allow',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,5 +1,7 @@
 # @summary 
 #   Manages the Squid daemon
+# @api
+#   private
 class squid::service inherits squid {
 
   service{$squid::service_name:

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,6 @@
 # @summary 
 #   Manages the Squid daemon
-# @api
-#   private
+# @api private
 class squid::service inherits squid {
 
   service{$squid::service_name:

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,5 @@
-# Class squid::service
-#
-# Manages the Squid daemon
-
+# @summary 
+#   Manages the Squid daemon
 class squid::service inherits squid {
 
   service{$squid::service_name:

--- a/manifests/snmp_access.pp
+++ b/manifests/snmp_access.pp
@@ -1,3 +1,31 @@
+# @summary 
+#   Defines snmp_access entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/snmp_access/ 
+# @example
+#   squid::snmp_access { 'monitoring hosts':
+#     action => 'allow',
+#   }
+#
+#   Adds a squid.conf line
+#   # snmp_access fragment for monitoring hosts
+#   snmp_access allow monitoring hosts
+#
+# @example
+#   squid::snmp_access { 'monitoring hosts':
+#     action    => 'allow',
+#     comment   => 'Our monitoring hosts are allowed',
+#   }
+#   Adds a squid.conf line:
+#   # Our monitoring hosts are allowed
+#   snmp_access allow monitoring hosts
+#
+# @param [Enum['allow', 'deny']] action
+#   Allow or deny access for $title
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
+# @param [String] comment
+#   snmp_access entry's preceding comment
 define squid::snmp_access (
   Enum['allow', 'deny']
           $action  = 'allow',

--- a/manifests/snmp_access.pp
+++ b/manifests/snmp_access.pp
@@ -20,11 +20,11 @@
 #   # Our monitoring hosts are allowed
 #   snmp_access allow monitoring hosts
 #
-# @param [Enum['allow', 'deny']] action
+# @param action
 #   Allow or deny access for $title
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
-# @param [String] comment
+# @param comment
 #   snmp_access entry's preceding comment
 define squid::snmp_access (
   Enum['allow', 'deny']

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -12,13 +12,13 @@
 #   snmp_port 1000
 #   endif
 #
-# @param [Variant[Pattern[/\d+/], Integer]] port 
+# @param port 
 #   Defaults to the namevar and is the port number.
-# @param [String] options 
+# @param options 
 #   A string to specify any options for the default. By default and empty string.
-# @option [Integer] process_number 
+# @option process_number 
 #   If set to and integer the snmp\_port is enabled only for a particular squid thread. Defaults to undef.
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::snmp_port (
   Variant[Pattern[/\d+/], Integer]

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -1,3 +1,25 @@
+# @summary 
+#   Defines snmp_port entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/snmp_port/ 
+# @example
+#   squid::snmp_port { '1000':
+#     process_number => 3
+#   }
+#
+#   Results in a squid configuration of
+#   if ${process_number} = 3
+#   snmp_port 1000
+#   endif
+#
+# @param [Variant[Pattern[/\d+/], Integer]] port 
+#   Defaults to the namevar and is the port number.
+# @param [String] options 
+#   A string to specify any options for the default. By default and empty string.
+# @option [Integer] process_number 
+#   If set to and integer the snmp\_port is enabled only for a particular squid thread. Defaults to undef.
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::snmp_port (
   Variant[Pattern[/\d+/], Integer]
                     $port           = $title,

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -16,7 +16,7 @@
 #   Defaults to the namevar and is the port number.
 # @param options 
 #   A string to specify any options for the default. By default and empty string.
-# @option process_number 
+# @param process_number 
 #   If set to and integer the snmp\_port is enabled only for a particular squid thread. Defaults to undef.
 # @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -1,3 +1,21 @@
+# @summary 
+#   Defines ssl_bump entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/ssl_bump/ 
+# @example
+#   squid::ssl_bump { 'all':
+#     action => 'bump',
+#   }
+# 
+#   Adds a squid.conf line
+#   ssl_bump bump all
+# 
+# @param [String] title 
+#   The name of acl the ssl_bump rule is applied to
+# @param action 
+#   The type of the ssl_bump, must be defined, e.g bump, peek, ..
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::ssl_bump (
   Enum[
     'bump',

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -10,11 +10,11 @@
 #   Adds a squid.conf line
 #   ssl_bump bump all
 # 
-# @param [String] title 
+# @param title 
 #   The name of acl the ssl_bump rule is applied to
 # @param action 
 #   The type of the ssl_bump, must be defined, e.g bump, peek, ..
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::ssl_bump (
   Enum[

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -10,12 +10,12 @@
 #   Adds a squid.conf line
 #   sslproxy_cert_error allow all
 # 
-# @param [String] value 
+# @param value 
 #   Defaults to the `namevar` the rule to allow or deny.
-# @param [Enum['allow', 'deny']] action 
+# @param action 
 #   Must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
 #   all allows appear before all denys. This can be overidden with the `order` parameter.
-# @param [String] order
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::sslproxy_cert_error (
   Enum['allow', 'deny']

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -1,3 +1,22 @@
+# @summary 
+#   Defines sslproxy_cert_error entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/sslproxy_cert_error/ 
+# @example
+#   squid::sslproxy_cert_error { 'all':
+#     action => 'allow',
+#   }
+# 
+#   Adds a squid.conf line
+#   sslproxy_cert_error allow all
+# 
+# @param [String] value 
+#   Defaults to the `namevar` the rule to allow or deny.
+# @param [Enum['allow', 'deny']] action 
+#   Must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
+#   all allows appear before all denys. This can be overidden with the `order` parameter.
+# @param [String] order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::sslproxy_cert_error (
   Enum['allow', 'deny']
           $action = 'allow',

--- a/types/pkgensure.pp
+++ b/types/pkgensure.pp
@@ -1,3 +1,5 @@
+# @summary
+#   Custom type representing package status and/or version
 type Squid::PkgEnsure = Variant[
   Pattern[/^\d.*/],
   Enum['present', 'latest', 'absent', 'purged', 'held', 'installed'],

--- a/types/size.pp
+++ b/types/size.pp
@@ -1,1 +1,3 @@
+# @summary
+#    Custom type containing the numeral value and the unit of messurement (Kilo- or Megabyte)
 type Squid::Size = Pattern[/^\d+ [KM]B$/]

--- a/types/size.pp
+++ b/types/size.pp
@@ -1,3 +1,3 @@
 # @summary
-#    Custom type containing the numeral value and the unit of messurement (Kilo- or Megabyte)
+#  Custom type containing the numeral value and the unit of messurement (Kilo- or Megabyte)
 type Squid::Size = Pattern[/^\d+ [KM]B$/]


### PR DESCRIPTION
## Pull Request (PR) description
This Pull Requests adds in-file documentation for typedefs and classes, to meet the puppet Style Guide criteria (Documentation on line 1 ).
The typedef documentation was taken from the Readme, with the removal of some of the markdown notation to improve readability.

#### This Pull Request (PR) fixes the following issues
puppet-lint failure (http://puppet-lint.com/checks/documentation/)
