### PR TITLE
Allow multiple access_log directives in squid.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@
 # @param url_rewrite_child_options
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
 # @param access_log
-#   Defaults to `daemon:/var/logs/squid/access.log squid`. http://www.squid-cache.org/Doc/config/access_log/
+#   Defaults to `daemon:/var/logs/squid/access.log squid`.  May be passed an Array.  http://www.squid-cache.org/Doc/config/access_log/
 # @param coredump_dir
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/coredump_dir/
 # @param error_directory
@@ -131,7 +131,7 @@
 #     url_rewrite_child_options => startup=1,
 #   }
 class squid (
-  String            $access_log                       = $squid::params::access_log,
+  Variant[String, Array[String]] $access_log          = $squid::params::access_log,
   Squid::Size       $cache_mem                        = $squid::params::cache_mem,
   String            $config                           = $squid::params::config,
   String            $config_group                     = $squid::params::config_group,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -84,6 +84,18 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^url_rewrite_children\s+16\stestoption=a$}) }
       end
 
+      context 'with access_log parameter set to an array' do
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            access_log: ['daemon:/somepath/access.log squid', 'syslog:daemon.info squid']
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^access_log\s+daemon:/somepath/access.log\s+squid$}) }
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^access_log\s+syslog:daemon.info\s+squid$}) }
+      end
+
       context 'with buffered_logs parameter set to true' do
         let :params do
           {

--- a/templates/squid.conf.header.erb
+++ b/templates/squid.conf.header.erb
@@ -23,7 +23,13 @@ logformat                     <%= @logformat %>
 <% unless @buffered_logs.nil? -%>
 buffered_logs                 <%= @buffered_logs?'on':'off' %>
 <% end -%>
+<% if @access_log.is_a?(Array) %>
+<% @access_log.each do |access_log_line| -%>
+access_log                    <%= access_log_line %>
+<% end -%>
+<% else -%>
 access_log                    <%= @access_log %>
+<% end -%>
 
 <% if @coredump_dir -%>
 coredump_dir                  <%= @coredump_dir %>


### PR DESCRIPTION
#### Pull Request (PR) description
This allows the access_log parameter to be a String (same as today) or an Array[String], to provide multiple `access_log` directives to squid.

#### This Pull Request (PR) fixes the following issues
n/a