### PR TITLE
Workaround for duplicate resource http_port #120

### DIFF
--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -54,7 +54,7 @@ define squid::cache_dir (
     }
   }
 
-  if $facts['os']['selinux'] == true {
+  if has_key($facts['os'],'selinux') and $facts['os']['selinux']['enabled'] == true {
     selinux::fcontext { "selinux fcontext squid_cache_t ${path}":
       seltype  => 'squid_cache_t',
       pathspec => "${path}(/.*)?",

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -85,7 +85,7 @@ define squid::http_port (
     order   => "30-${order}",
   }
 
-  if $facts['os']['selinux'] == true {
+  if has_key($facts['os'],'selinux') and $facts['os']['selinux']['enabled'] == true {
     selinux::port { "selinux port squid_port_t ${_port}":
       ensure   => 'present',
       seltype  => 'squid_port_t',

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -86,11 +86,11 @@ define squid::http_port (
   }
 
   if has_key($facts['os'],'selinux') and $facts['os']['selinux']['enabled'] == true {
-    selinux::port { "selinux port squid_port_t ${_port}":
-      ensure   => 'present',
-      seltype  => 'squid_port_t',
-      protocol => 'tcp',
-      port     => $_port,
-    }
+    ensure_resource('selinux::port', "selinux port squid_port_t ${_port}", {
+        ensure   => 'present',
+        seltype  => 'squid_port_t',
+        protocol => 'tcp',
+        port     => $_port,
+    })
   }
 }


### PR DESCRIPTION
This is a rebase ontop of master for: https://github.com/voxpupuli/puppet-squid/pull/135
The review comment from @ekohl has been adressed in the process.

The module is now able to handle multiple server
declarations for the same port on different IPs.

