### PR TITLE
Puppet-lint fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'voxpupuli-test', '>= 1.0.0',  :require => false
+  gem 'voxpupuli-test', '>= 2.0.0',  :require => false
   gem 'coveralls',                   :require => false
   gem 'simplecov-console',           :require => false
 end

--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -26,7 +26,7 @@ define squid::acl (
 ) {
   $type_cleaned = regsubst($type,':','','G')
 
-  concat::fragment{ "squid_acl_${aclname}":
+  concat::fragment { "squid_acl_${aclname}":
     target  => $squid::config,
     content => template('squid/squid.conf.acl.erb'),
     order   => "10-${order}-${type_cleaned}",

--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -31,5 +31,4 @@ define squid::acl (
     content => template('squid/squid.conf.acl.erb'),
     order   => "10-${order}-${type_cleaned}",
   }
-
 }

--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -24,10 +24,9 @@ define squid::acl (
   String $order   = '05',
   String $comment = "acl fragment for ${aclname}",
 ) {
-
   $type_cleaned = regsubst($type,':','','G')
 
-  concat::fragment{"squid_acl_${aclname}":
+  concat::fragment{ "squid_acl_${aclname}":
     target  => $squid::config,
     content => template('squid/squid.conf.acl.erb'),
     order   => "10-${order}-${type_cleaned}",

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -1,7 +1,7 @@
-# @summary 
-#   Defines auth_param entries  for a squid server.
-# @see 
-#   http://www.squid-cache.org/Doc/config/auth_param/ 
+# @summary
+#   Defines auth_param entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/auth_param/
 # @example
 #   squid::auth_param { 'basic auth_param':
 #     scheme  => 'basic',
@@ -17,19 +17,18 @@
 #   auth_param basic children 5
 #   auth_param basic realm Squid Basic Authentication
 #   auth_param basic credentialsttl 5 hours
-# 
-# @param scheme 
+#
+# @param scheme
 #   The scheme used for authentication must be defined. Valid values are 'basic', 'digest', 'negotiate' and 'ntlm'.
-# @param entries 
+# @param entries
 #   An array of entries, multiple members results in multiple lines in squid.conf
-# @param order 
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::auth_param (
-  Enum['basic', 'digest', 'negotiate', 'ntlm']
-          $scheme,
-  Array   $entries,
-  String  $auth_param_name = $title,
-  String  $order           = '40',
+  Enum['basic', 'digest', 'negotiate', 'ntlm'] $scheme,
+  Array  $entries,
+  String $auth_param_name = $title,
+  String $order           = '40',
 ) {
   concat::fragment { "squid_auth_param_${auth_param_name}":
     target  => $squid::config,

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -36,5 +36,4 @@ define squid::auth_param (
     content => template('squid/squid.conf.auth_param.erb'),
     order   => "05-${order}-${scheme}",
   }
-
 }

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -31,7 +31,7 @@ define squid::auth_param (
   String  $auth_param_name = $title,
   String  $order           = '40',
 ) {
-  concat::fragment{ "squid_auth_param_${auth_param_name}":
+  concat::fragment { "squid_auth_param_${auth_param_name}":
     target  => $squid::config,
     content => template('squid/squid.conf.auth_param.erb'),
     order   => "05-${order}-${scheme}",

--- a/manifests/auth_param.pp
+++ b/manifests/auth_param.pp
@@ -31,8 +31,7 @@ define squid::auth_param (
   String  $auth_param_name = $title,
   String  $order           = '40',
 ) {
-
-  concat::fragment{"squid_auth_param_${auth_param_name}":
+  concat::fragment{ "squid_auth_param_${auth_param_name}":
     target  => $squid::config,
     content => template('squid/squid.conf.auth_param.erb'),
     order   => "05-${order}-${scheme}",

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -24,7 +24,7 @@ define squid::cache (
   String  $order   = '05',
   String  $comment = "cache fragment for ${value}"
 ) {
-  concat::fragment{ "squid_cache_${value}":
+  concat::fragment { "squid_cache_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.cache.erb'),
     order   => "21-${order}-${action}",

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -1,6 +1,6 @@
-# @summary 
-#   Defines cache entries  for a squid server.
-# @see 
+# @summary
+#   Defines cache entries for a squid server.
+# @see
 #   http://www.squid-cache.org/Doc/config/cache/
 # @example
 #   squid::cache { 'our_network_hosts_acl':
@@ -18,11 +18,10 @@
 # @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::cache (
-  Enum['allow', 'deny']
-          $action  = 'allow',
-  String  $value   = $title,
-  String  $order   = '05',
-  String  $comment = "cache fragment for ${value}"
+  Enum['allow', 'deny'] $action = 'allow',
+  String $value   = $title,
+  String $order   = '05',
+  String $comment = "cache fragment for ${value}"
 ) {
   concat::fragment { "squid_cache_${value}":
     target  => $squid::config,

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -29,5 +29,4 @@ define squid::cache (
     content => template('squid/squid.conf.cache.erb'),
     order   => "21-${order}-${action}",
   }
-
 }

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -24,8 +24,7 @@ define squid::cache (
   String  $order   = '05',
   String  $comment = "cache fragment for ${value}"
 ) {
-
-  concat::fragment{"squid_cache_${value}":
+  concat::fragment{ "squid_cache_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.cache.erb'),
     order   => "21-${order}-${action}",

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -38,15 +38,14 @@ define squid::cache_dir (
   String            $order          = '05',
   Boolean           $manage_dir     = true,
 ) {
-
-  concat::fragment{"squid_cache_dir_${path}":
+  concat::fragment{ "squid_cache_dir_${path}":
     target  => $squid::config,
     content => template('squid/squid.conf.cache_dir.erb'),
     order   => "50-${order}",
   }
 
   if $manage_dir {
-    file{$path:
+    file{ $path:
       ensure  => directory,
       owner   => $squid::daemon_user,
       group   => $squid::daemon_group,
@@ -56,13 +55,13 @@ define squid::cache_dir (
   }
 
   if $facts['os']['selinux'] == true {
-    selinux::fcontext{"selinux fcontext squid_cache_t ${path}":
+    selinux::fcontext{ "selinux fcontext squid_cache_t ${path}":
       seltype  => 'squid_cache_t',
       pathspec => "${path}(/.*)?",
       require  => File[$path],
       notify   => Selinux::Exec_restorecon["selinux restorecon ${path}"],
     }
-    selinux::exec_restorecon{"selinux restorecon ${path}":
+    selinux::exec_restorecon{ "selinux restorecon ${path}":
       path        => $path,
       refreshonly => true,
     }

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -66,5 +66,4 @@ define squid::cache_dir (
       refreshonly => true,
     }
   }
-
 }

--- a/manifests/cache_dir.pp
+++ b/manifests/cache_dir.pp
@@ -38,14 +38,14 @@ define squid::cache_dir (
   String            $order          = '05',
   Boolean           $manage_dir     = true,
 ) {
-  concat::fragment{ "squid_cache_dir_${path}":
+  concat::fragment { "squid_cache_dir_${path}":
     target  => $squid::config,
     content => template('squid/squid.conf.cache_dir.erb'),
     order   => "50-${order}",
   }
 
   if $manage_dir {
-    file{ $path:
+    file { $path:
       ensure  => directory,
       owner   => $squid::daemon_user,
       group   => $squid::daemon_group,
@@ -55,13 +55,13 @@ define squid::cache_dir (
   }
 
   if $facts['os']['selinux'] == true {
-    selinux::fcontext{ "selinux fcontext squid_cache_t ${path}":
+    selinux::fcontext { "selinux fcontext squid_cache_t ${path}":
       seltype  => 'squid_cache_t',
       pathspec => "${path}(/.*)?",
       require  => File[$path],
       notify   => Selinux::Exec_restorecon["selinux restorecon ${path}"],
     }
-    selinux::exec_restorecon{ "selinux restorecon ${path}":
+    selinux::exec_restorecon { "selinux restorecon ${path}":
       path        => $path,
       refreshonly => true,
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,7 +44,6 @@ class squid::config (
   $extra_config_sections         = $squid::extra_config_sections,
   $squid_bin_path                = $squid::squid_bin_path,
 ) inherits squid {
-
   concat { $config:
     ensure       => present,
     owner        => $config_user,
@@ -53,7 +52,7 @@ class squid::config (
     validate_cmd => "${squid_bin_path} -k parse -f %",
   }
 
-  concat::fragment{'squid_header':
+  concat::fragment{ 'squid_header':
     target  => $config,
     content => template('squid/squid.conf.header.erb'),
     order   => '01',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,7 +52,7 @@ class squid::config (
     validate_cmd => "${squid_bin_path} -k parse -f %",
   }
 
-  concat::fragment{ 'squid_header':
+  concat::fragment { 'squid_header':
     target  => $config,
     content => template('squid/squid.conf.header.erb'),
     order   => '01',

--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -59,7 +59,7 @@ define squid::extra_config_section (
   Variant[Array,Hash] $config_entries = {},
   String              $order   = '60',
 ) {
-  concat::fragment{ "squid_extra_config_section_${comment}":
+  concat::fragment { "squid_extra_config_section_${comment}":
     target  => $squid::config,
     content => template('squid/squid.conf.extra_config_section.erb'),
     order   => "${order}-${comment}",

--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -59,8 +59,7 @@ define squid::extra_config_section (
   Variant[Array,Hash] $config_entries = {},
   String              $order   = '60',
 ) {
-
-  concat::fragment{"squid_extra_config_section_${comment}":
+  concat::fragment{ "squid_extra_config_section_${comment}":
     target  => $squid::config,
     content => template('squid/squid.conf.extra_config_section.erb'),
     order   => "${order}-${comment}",

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -1,16 +1,16 @@
-# @summary 
+# @summary
 #   Defines http_access entries for a squid server.
-# @see 
+# @see
 #   https://github.com/puppetlabs/puppetlabs-docker/blob/master/REFERENCE.md
 # @example
 #   squid::http_access { 'our_networks hosts':
 #     action => 'allow',
 #   }
-# 
+#
 #   Adds a squid.conf line
 #   # http_access fragment for out_networks hosts
 #   http_access allow our_networks hosts
-# 
+#
 # @example
 #   squid::http_access { 'our_networks hosts':
 #     action    => 'allow',
@@ -29,11 +29,10 @@
 # @param comment
 #   http_access entry's preceding comment
 define squid::http_access (
-  Enum['allow', 'deny']
-          $action  = 'allow',
-  String  $value   = $title,
-  String  $order   = '05',
-  String  $comment = "http_access fragment for ${value}"
+  Enum['allow', 'deny'] $action = 'allow',
+  String $value   = $title,
+  String $order   = '05',
+  String $comment = "http_access fragment for ${value}"
 ) {
   concat::fragment { "squid_http_access_${value}":
     target  => $squid::config,

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -35,7 +35,7 @@ define squid::http_access (
   String  $order   = '05',
   String  $comment = "http_access fragment for ${value}"
 ) {
-  concat::fragment{ "squid_http_access_${value}":
+  concat::fragment { "squid_http_access_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.http_access.erb'),
     order   => "20-${order}-${action}",

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -35,8 +35,7 @@ define squid::http_access (
   String  $order   = '05',
   String  $comment = "http_access fragment for ${value}"
 ) {
-
-  concat::fragment{"squid_http_access_${value}":
+  concat::fragment{ "squid_http_access_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.http_access.erb'),
     order   => "20-${order}-${action}",

--- a/manifests/http_access.pp
+++ b/manifests/http_access.pp
@@ -40,5 +40,4 @@ define squid::http_access (
     content => template('squid/squid.conf.http_access.erb'),
     order   => "20-${order}-${action}",
   }
-
 }

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -21,13 +21,13 @@
 # @param title
 #   The title/namevar may be in the form `port` or `host:port` to provide the below values. Otherwise,
 #   specify `port` explicitly, and `host` if desired.
-# @param port 
+# @param port
 #   Defaults to the port of the namevar and is the port number to listen on.
-# @param host 
+# @param host
 #   Defaults to the host part of the namevar and is the interface to listen on. If not specified, Squid listens on all interfaces.
-# @param options 
+# @param options
 #   A string to specify any options for the default. By default and empty string.
-# @param ssl 
+# @param ssl
 #   When set to `true` creates https_port entries. Defaults to `false`.
 # @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
@@ -74,12 +74,14 @@ define squid::http_port (
 
   concat::fragment { "squid_${protocol}_port_${_title}":
     target  => $squid::config,
-    content => epp('squid/squid.conf.port.epp', {
-      title     => $_title,
-      protocol  => $protocol,
-      host_port => $_host_port,
-      options   => $options,
-    }),
+    content => epp('squid/squid.conf.port.epp',
+      {
+        title     => $_title,
+        protocol  => $protocol,
+        host_port => $_host_port,
+        options   => $options,
+      }
+    ),
     order   => "30-${order}",
   }
 

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -72,7 +72,7 @@ define squid::http_port (
     default => 'http',
   }
 
-  concat::fragment{ "squid_${protocol}_port_${_title}":
+  concat::fragment { "squid_${protocol}_port_${_title}":
     target  => $squid::config,
     content => epp('squid/squid.conf.port.epp', {
       title     => $_title,
@@ -84,7 +84,7 @@ define squid::http_port (
   }
 
   if $facts['os']['selinux'] == true {
-    selinux::port{ "selinux port squid_port_t ${_port}":
+    selinux::port { "selinux port squid_port_t ${_port}":
       ensure   => 'present',
       seltype  => 'squid_port_t',
       protocol => 'tcp',

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -91,5 +91,4 @@ define squid::http_port (
       port     => $_port,
     }
   }
-
 }

--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -72,7 +72,7 @@ define squid::http_port (
     default => 'http',
   }
 
-  concat::fragment{"squid_${protocol}_port_${_title}":
+  concat::fragment{ "squid_${protocol}_port_${_title}":
     target  => $squid::config,
     content => epp('squid/squid.conf.port.epp', {
       title     => $_title,
@@ -84,7 +84,7 @@ define squid::http_port (
   }
 
   if $facts['os']['selinux'] == true {
-    selinux::port{"selinux port squid_port_t ${_port}":
+    selinux::port{ "selinux port squid_port_t ${_port}":
       ensure   => 'present',
       seltype  => 'squid_port_t',
       protocol => 'tcp',

--- a/manifests/https_port.pp
+++ b/manifests/https_port.pp
@@ -1,18 +1,17 @@
-# @summary 
+# @summary
 #   Defines https_port entries for a squid server. Results are the same with http_port and ssl set to `true`.
-# @see 
+# @see
 #   http://www.squid-cache.org/Doc/config/https_port/
-# @param port 
+# @param port
 #   defaults to the namevar and is the port number.
-# @param options 
+# @param options
 #   A string to specify any options to add to the https_port line.  Defaults to an empty string.
 # @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::https_port (
-  Variant[Pattern[/\d+/], Integer]
-          $port    = $title,
-  String  $options = '',
-  String  $order   = '05',
+  Variant[Pattern[/\d+/], Integer] $port = $title,
+  String $options = '',
+  String $order   = '05',
 ) {
   squid::http_port { "${port}": # lint:ignore:only_variable_string
     ssl     => true,

--- a/manifests/https_port.pp
+++ b/manifests/https_port.pp
@@ -19,5 +19,4 @@ define squid::https_port (
     options => $options,
     order   => $order,
   }
-
 }

--- a/manifests/https_port.pp
+++ b/manifests/https_port.pp
@@ -14,7 +14,6 @@ define squid::https_port (
   String  $options = '',
   String  $order   = '05',
 ) {
-
   squid::http_port { "${port}": # lint:ignore:only_variable_string
     ssl     => true,
     options => $options,

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -1,4 +1,4 @@
-# @summary 
+# @summary
 #   Defines icp_access entries for a squid server.
 # @see http://www.squid-cache.org/Doc/config/icp_access/
 # @example
@@ -9,16 +9,15 @@
 #   Adds a squid.conf line
 #   icp_access allow our_networks hosts
 #
-# @param action 
+# @param action
 #   Must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
 #   all allows appear before all denys. This can be overidden with the `order` parameter.
-# @param order 
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::icp_access (
-  Enum['allow', 'deny']
-          $action = 'allow',
-  String  $value  = $title,
-  String  $order  = '05',
+  Enum['allow', 'deny'] $action = 'allow',
+  String $value = $title,
+  String $order = '05',
 ) {
   concat::fragment { "squid_icp_access_${value}":
     target  => $squid::config,

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -25,5 +25,4 @@ define squid::icp_access (
     content => template('squid/squid.conf.icp_access.erb'),
     order   => "30-${order}-${action}",
   }
-
 }

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -20,8 +20,7 @@ define squid::icp_access (
   String  $value  = $title,
   String  $order  = '05',
 ) {
-
-  concat::fragment{"squid_icp_access_${value}":
+  concat::fragment{ "squid_icp_access_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.icp_access.erb'),
     order   => "30-${order}-${action}",

--- a/manifests/icp_access.pp
+++ b/manifests/icp_access.pp
@@ -20,7 +20,7 @@ define squid::icp_access (
   String  $value  = $title,
   String  $order  = '05',
 ) {
-  concat::fragment{ "squid_icp_access_${value}":
+  concat::fragment { "squid_icp_access_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.icp_access.erb'),
     order   => "30-${order}-${action}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
-# @summary 
-#   Module for configuring the squid caching service. 
+# @summary
+#   Module for configuring the squid caching service.
 #   The module will set the SELINUX-context for the cache_dir and port, needs puppet-selinux
 #
 # @example The set up a simple squid server with a cache to forward http port 80 requests.
@@ -14,95 +14,95 @@
 #   squid::http_access{ '!Safe_ports':
 #     action => deny,
 #   }
-# 
-# @param ensure_service 
+#
+# @param ensure_service
 #   The ensure value of the squid service, defaults to `running`.
-# @param enable_service 
+# @param enable_service
 #   The enable value of the squid service, defaults to `true`.
-# @param config 
+# @param config
 #   Location of squid.conf file, defaults to `/etc/squid/squid.conf`.
-# @param config_user 
+# @param config_user
 #   User which owns the config file, default depends on `$operatingsystem`
-# @param config_group 
+# @param config_group
 #   Group which owns the config file, default depends on `$operatingsystem`
-# @param daemon_user 
+# @param daemon_user
 #   User which runs the squid daemon, this is used for ownership of the cache directory, default depends on `$operatingsystem`
-# @param daemon_group 
+# @param daemon_group
 #   Group which runs the squid daemon, this is used for ownership of the cache directory, default depends on `$operatingsystem`
-# @param cache_mem 
+# @param cache_mem
 #   Defaults to `256 MB`. http://www.squid-cache.org/Doc/config/cache_mem/
-# @param cache_replacement_policy 
+# @param cache_replacement_policy
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/cache_replacement_policy/
-# @param memory_replacement_policy 
+# @param memory_replacement_policy
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_replacement_policy/
-# @param memory_cache_shared 
+# @param memory_cache_shared
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/memory_cache_shared/.
-# @param maximum_object_size_in_memory 
+# @param maximum_object_size_in_memory
 #   Defaults to `512 KB`. http://www.squid-cache.org/Doc/config/maximum_object_size_in_memory/
-# @param url_rewrite_program 
+# @param url_rewrite_program
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_program/
-# @param url_rewrite_children 
+# @param url_rewrite_children
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
-# @param url_rewrite_child_options 
+# @param url_rewrite_child_options
 #   Defaults to undef http://www.squid-cache.org/Doc/config/url_rewrite_children/
-# @param access_log 
+# @param access_log
 #   Defaults to `daemon:/var/logs/squid/access.log squid`. http://www.squid-cache.org/Doc/config/access_log/
-# @param coredump_dir 
+# @param coredump_dir
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/coredump_dir/
-# @param error_directory 
+# @param error_directory
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/error_directory/
-# @param err_page_stylesheet 
+# @param err_page_stylesheet
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/err_page_stylesheet/
-# @param package_name 
+# @param package_name
 #   Name of the squid package to manage, default depends on `$operatingsystem`
-# @param package_ensure 
+# @param package_ensure
 #   Package status and/or version, default to present
-# @param service_name 
+# @param service_name
 #   Name of the squid service to manage, default depends on `$operatingsystem`
-# @param max_filedescriptors 
+# @param max_filedescriptors
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/max_filedescriptors/
-# @param workers 
+# @param workers
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/workers/
-# @param snmp_incoming_address 
+# @param snmp_incoming_address
 #   Defaults to undef. Can be set to an IP address to only listen for snmp requests on an individual interface. http://www.squid-cache.org/Doc/config/snmp_incoming_address/
-# @param buffered_logs 
+# @param buffered_logs
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/buffered_logs/
-# @param acls 
+# @param acls
 #   Defaults to undef. If you pass in a hash of acl entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/acl/
-# @param visible_hostname 
+# @param visible_hostname
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/visible_hostname/
-# @param via 
+# @param via
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/via/
-# @param httpd_suppress_version_string 
+# @param httpd_suppress_version_string
 #   Defaults to undef. http://www.squid-cache.org/Doc/config/httpd_suppress_version_string/
-# @param forwarded_for 
+# @param forwarded_for
 #   Defaults to undef. supported values are "on", "off", "transparent", "delete", "truncate". http://www.squid-cache.org/Doc/config/forwarded_for/
-# @param http_access 
+# @param http_access
 #   Defaults to undef. If you pass in a hash of http_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_access/
-# @param http_ports 
+# @param http_ports
 #   Defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/http_port/
-# @param https_ports 
+# @param https_ports
 #   Defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/https_port/
-# @param icp_access 
+# @param icp_access
 #   Defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/icp_access/
-# @param refresh_patterns 
+# @param refresh_patterns
 #   Defaults to undef.  If you pass a hash of refresh_pattern entires, they will be defined automatically. http://www.squid-cache.org/Doc/config/refresh_pattern/
-# @param snmp_ports 
+# @param snmp_ports
 #   Defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/snmp_port/
-# @param send_hit 
+# @param send_hit
 #   Defaults to undef. If you pass in a hash of send_hit entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/send_hit/
-# @param cache_dirs 
+# @param cache_dirs
 #   Defaults to undef. If you pass in a hash of cache_dir entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/cache_dir/
-# @param ssl_bump 
+# @param ssl_bump
 #   Defaults to undef. If you pass in a hash of ssl_bump entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/ssl_bump/
-# @param sslproxy_cert_error 
+# @param sslproxy_cert_error
 #   Defaults to undef. If you pass in a hash of sslproxy_cert_error entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/sslproxy_cert_error/
-# @param extra_config_sections 
+# @param extra_config_sections
 #   Defaults to empty hash. If you pass in a hash of `extra_config_section` resources, they will be defined automatically.
-# @param service_restart 
-#   Defaults to undef. Overrides service resource restart command to be executed. 
+# @param service_restart
+#   Defaults to undef. Overrides service resource restart command to be executed.
 #   It can be used to perform a soft reload of the squid service.
-# @param squid_bin_path 
+# @param squid_bin_path
 #   Path to the squid binary, default depends on `$operatingsystem`
 # @example
 #   class { 'squid':
@@ -110,7 +110,7 @@
 #     workers      => 3,
 #     coredump_dir => '/var/spool/squid',
 #   }
-# 
+#
 # @example
 #   class { 'squid':
 #     cache_mem                 => '512 MB',
@@ -150,8 +150,7 @@ class squid (
   Optional[String]  $cache_replacement_policy      = $squid::params::cache_replacement_policy,
   Optional[String]  $memory_replacement_policy     = $squid::params::memory_replacement_policy,
   Optional[Boolean] $httpd_suppress_version_string = $squid::params::httpd_suppress_version_string,
-  Optional[Variant[Enum['on', 'off', 'transparent', 'delete', 'truncate'], Boolean]]
-                    $forwarded_for                 = $squid::params::forwarded_for,
+  Optional[Variant[Enum['on', 'off', 'transparent', 'delete', 'truncate'], Boolean]] $forwarded_for = $squid::params::forwarded_for,
   Optional[String]  $visible_hostname              = $squid::params::visible_hostname,
   Optional[Boolean] $via                           = $squid::params::via,
   Optional[Hash]    $acls                          = $squid::params::acls,
@@ -172,16 +171,14 @@ class squid (
   Optional[String]  $logformat                     = $squid::params::logformat,
   Optional[Boolean] $buffered_logs                 = $squid::params::buffered_logs,
   Optional[Integer] $max_filedescriptors           = $squid::params::max_filedescriptors,
-  Optional[Variant[Enum['on', 'off'], Boolean]]
-                    $memory_cache_shared              = $squid::params::memory_cache_shared,
-  Optional[Hash]    $refresh_patterns                 = $squid::params::refresh_patterns,
-  Optional[Stdlib::Compat::Ip_address]
-                    $snmp_incoming_address            = $squid::params::snmp_incoming_address,
-  Optional[Hash]    $snmp_ports                       = $squid::params::snmp_ports,
-  Optional[Hash]    $ssl_bump                         = $squid::params::ssl_bump,
-  Optional[Hash]    $sslproxy_cert_error              = $squid::params::sslproxy_cert_error,
-  Optional[Integer] $workers                          = $squid::params::workers,
-  Optional[String]  $service_restart                  = $squid::params::service_restart,
+  Optional[Variant[Enum['on', 'off'], Boolean]] $memory_cache_shared = $squid::params::memory_cache_shared,
+  Optional[Hash]    $refresh_patterns              = $squid::params::refresh_patterns,
+  Optional[Stdlib::Compat::Ip_address] $snmp_incoming_address = $squid::params::snmp_incoming_address,
+  Optional[Hash]    $snmp_ports                    = $squid::params::snmp_ports,
+  Optional[Hash]    $ssl_bump                      = $squid::params::ssl_bump,
+  Optional[Hash]    $sslproxy_cert_error           = $squid::params::sslproxy_cert_error,
+  Optional[Integer] $workers                       = $squid::params::workers,
+  Optional[String]  $service_restart               = $squid::params::service_restart,
 ) inherits ::squid::params {
   contain squid::install
   contain squid::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,7 +183,6 @@ class squid (
   Optional[Integer] $workers                          = $squid::params::workers,
   Optional[String]  $service_restart                  = $squid::params::service_restart,
 ) inherits ::squid::params {
-
   contain squid::install
   contain squid::config
   contain squid::service

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,5 @@ class squid::install {
   package { $squid::package_name:
     ensure => $squid::package_ensure,
   }
-
 }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,8 @@
 # @summary
 #   Installs the squid package
 # @api private
-class squid::install  {
-  package{ $squid::package_name:
+class squid::install {
+  package { $squid::package_name:
     ensure => $squid::package_ensure,
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,4 +6,3 @@ class squid::install {
     ensure => $squid::package_ensure,
   }
 }
-

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,8 +2,7 @@
 #   Installs the squid package
 # @api private
 class squid::install  {
-
-  package{$squid::package_name:
+  package{ $squid::package_name:
     ensure => $squid::package_ensure,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,6 @@
 #   This class manages Squid parameters
 # @api private
 class squid::params {
-
   $ensure_service                = 'running'
   $enable_service                = true
   $cache_mem                     = '256 MB'

--- a/manifests/refresh_pattern.pp
+++ b/manifests/refresh_pattern.pp
@@ -72,7 +72,7 @@ define squid::refresh_pattern (
   String  $pattern        = $title,
   String  $comment        = "refresh_pattern fragment for ${pattern}",
 ) {
-  concat::fragment{ "squid_refresh_pattern_${pattern}":
+  concat::fragment { "squid_refresh_pattern_${pattern}":
     target  => $squid::config,
     content => template('squid/squid.conf.refresh_pattern.erb'),
     order   => "45-${order}",

--- a/manifests/refresh_pattern.pp
+++ b/manifests/refresh_pattern.pp
@@ -72,8 +72,7 @@ define squid::refresh_pattern (
   String  $pattern        = $title,
   String  $comment        = "refresh_pattern fragment for ${pattern}",
 ) {
-
-  concat::fragment{"squid_refresh_pattern_${pattern}":
+  concat::fragment{ "squid_refresh_pattern_${pattern}":
     target  => $squid::config,
     content => template('squid/squid.conf.refresh_pattern.erb'),
     order   => "45-${order}",

--- a/manifests/send_hit.pp
+++ b/manifests/send_hit.pp
@@ -25,8 +25,7 @@ define squid::send_hit (
   String  $order   = '05',
   String  $comment = "send_hit fragment for ${value}"
 ) {
-
-  concat::fragment{"squid_send_hit_${value}":
+  concat::fragment{ "squid_send_hit_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.send_hit.erb'),
     order   => "21-${order}-${action}",

--- a/manifests/send_hit.pp
+++ b/manifests/send_hit.pp
@@ -30,5 +30,4 @@ define squid::send_hit (
     content => template('squid/squid.conf.send_hit.erb'),
     order   => "21-${order}-${action}",
   }
-
 }

--- a/manifests/send_hit.pp
+++ b/manifests/send_hit.pp
@@ -25,7 +25,7 @@ define squid::send_hit (
   String  $order   = '05',
   String  $comment = "send_hit fragment for ${value}"
 ) {
-  concat::fragment{ "squid_send_hit_${value}":
+  concat::fragment { "squid_send_hit_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.send_hit.erb'),
     order   => "21-${order}-${action}",

--- a/manifests/send_hit.pp
+++ b/manifests/send_hit.pp
@@ -1,4 +1,4 @@
-# @summary 
+# @summary
 #   Defines send_hit for a squid server.
 # @see
 #   http://www.squid-cache.org/Doc/config/send_hit/
@@ -10,20 +10,19 @@
 #   Adds the following squid.conf line:
 #   send_hit deny PragmaNoCache
 #
-# @param value 
+# @param value
 #   Defaults to the `namevar`. The rule to allow or deny.
-# @param action 
+# @param action
 #   Must one of `deny` or `allow`
-# @param order 
+# @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
-# @param comment 
+# @param comment
 #   A preceeding comment to add to the configuration file.
 define squid::send_hit (
-  Enum['allow', 'deny']
-          $action  = 'allow',
-  String  $value   = $title,
-  String  $order   = '05',
-  String  $comment = "send_hit fragment for ${value}"
+  Enum['allow', 'deny'] $action = 'allow',
+  String $value   = $title,
+  String $order   = '05',
+  String $comment = "send_hit fragment for ${value}"
 ) {
   concat::fragment { "squid_send_hit_${value}":
     target  => $squid::config,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,7 +2,7 @@
 #   Manages the Squid daemon
 # @api private
 class squid::service inherits squid {
-  service{ $squid::service_name:
+  service { $squid::service_name:
     ensure  => $squid::ensure_service,
     enable  => $squid::enable_service,
     restart => $squid::service_restart,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,8 +2,7 @@
 #   Manages the Squid daemon
 # @api private
 class squid::service inherits squid {
-
-  service{$squid::service_name:
+  service{ $squid::service_name:
     ensure  => $squid::ensure_service,
     enable  => $squid::enable_service,
     restart => $squid::service_restart,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,5 +7,4 @@ class squid::service inherits squid {
     enable  => $squid::enable_service,
     restart => $squid::service_restart,
   }
-
 }

--- a/manifests/snmp_access.pp
+++ b/manifests/snmp_access.pp
@@ -33,8 +33,7 @@ define squid::snmp_access (
   String  $order   = '05',
   String  $comment = "snmp_access fragment for ${value}"
 ) {
-
-  concat::fragment{"squid_snmp_access_${value}":
+  concat::fragment{ "squid_snmp_access_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.snmp_access.erb'),
     order   => "20-${order}-${action}",

--- a/manifests/snmp_access.pp
+++ b/manifests/snmp_access.pp
@@ -1,7 +1,7 @@
-# @summary 
+# @summary
 #   Defines snmp_access entries for a squid server.
 # @see
-#   http://www.squid-cache.org/Doc/config/snmp_access/ 
+#   http://www.squid-cache.org/Doc/config/snmp_access/
 # @example
 #   squid::snmp_access { 'monitoring hosts':
 #     action => 'allow',
@@ -27,11 +27,10 @@
 # @param comment
 #   snmp_access entry's preceding comment
 define squid::snmp_access (
-  Enum['allow', 'deny']
-          $action  = 'allow',
-  String  $value   = $title,
-  String  $order   = '05',
-  String  $comment = "snmp_access fragment for ${value}"
+  Enum['allow', 'deny'] $action = 'allow',
+  String $value   = $title,
+  String $order   = '05',
+  String $comment = "snmp_access fragment for ${value}"
 ) {
   concat::fragment { "squid_snmp_access_${value}":
     target  => $squid::config,

--- a/manifests/snmp_access.pp
+++ b/manifests/snmp_access.pp
@@ -38,5 +38,4 @@ define squid::snmp_access (
     content => template('squid/squid.conf.snmp_access.erb'),
     order   => "20-${order}-${action}",
   }
-
 }

--- a/manifests/snmp_access.pp
+++ b/manifests/snmp_access.pp
@@ -33,7 +33,7 @@ define squid::snmp_access (
   String  $order   = '05',
   String  $comment = "snmp_access fragment for ${value}"
 ) {
-  concat::fragment{ "squid_snmp_access_${value}":
+  concat::fragment { "squid_snmp_access_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.snmp_access.erb'),
     order   => "20-${order}-${action}",

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -1,7 +1,7 @@
-# @summary 
+# @summary
 #   Defines snmp_port entries for a squid server.
 # @see
-#   http://www.squid-cache.org/Doc/config/snmp_port/ 
+#   http://www.squid-cache.org/Doc/config/snmp_port/
 # @example
 #   squid::snmp_port { '1000':
 #     process_number => 3
@@ -12,17 +12,16 @@
 #   snmp_port 1000
 #   endif
 #
-# @param port 
+# @param port
 #   Defaults to the namevar and is the port number.
-# @param options 
+# @param options
 #   A string to specify any options for the default. By default and empty string.
-# @param process_number 
+# @param process_number
 #   If set to and integer the snmp\_port is enabled only for a particular squid thread. Defaults to undef.
 # @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::snmp_port (
-  Variant[Pattern[/\d+/], Integer]
-                    $port           = $title,
+  Variant[Pattern[/\d+/], Integer] $port = $title,
   String            $options        = '',
   String            $order          = '05',
   Optional[Integer] $process_number = undef,

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -27,8 +27,7 @@ define squid::snmp_port (
   String            $order          = '05',
   Optional[Integer] $process_number = undef,
 ) {
-
-  concat::fragment{"squid_snmp_port_${port}":
+  concat::fragment{ "squid_snmp_port_${port}":
     target  => $squid::config,
     content => template('squid/squid.conf.snmp_port.erb'),
     order   => "40-${order}",

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -27,7 +27,7 @@ define squid::snmp_port (
   String            $order          = '05',
   Optional[Integer] $process_number = undef,
 ) {
-  concat::fragment{ "squid_snmp_port_${port}":
+  concat::fragment { "squid_snmp_port_${port}":
     target  => $squid::config,
     content => template('squid/squid.conf.snmp_port.erb'),
     order   => "40-${order}",

--- a/manifests/snmp_port.pp
+++ b/manifests/snmp_port.pp
@@ -32,5 +32,4 @@ define squid::snmp_port (
     content => template('squid/squid.conf.snmp_port.erb'),
     order   => "40-${order}",
   }
-
 }

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -31,7 +31,7 @@ define squid::ssl_bump (
   String  $value  = $title,
   String  $order  = '05',
 ) {
-  concat::fragment{ "squid_ssl_bump_${action}_${value}":
+  concat::fragment { "squid_ssl_bump_${action}_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.ssl_bump.erb'),
     order   => "25-${order}-${action}",

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -1,35 +1,25 @@
-# @summary 
+# @summary
 #   Defines ssl_bump entries for a squid server.
 # @see
-#   http://www.squid-cache.org/Doc/config/ssl_bump/ 
+#   http://www.squid-cache.org/Doc/config/ssl_bump/
 # @example
 #   squid::ssl_bump { 'all':
 #     action => 'bump',
 #   }
-# 
+#
 #   Adds a squid.conf line
 #   ssl_bump bump all
-# 
-# @param title 
+#
+# @param title
 #   The name of acl the ssl_bump rule is applied to
-# @param action 
+# @param action
 #   The type of the ssl_bump, must be defined, e.g bump, peek, ..
 # @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::ssl_bump (
-  Enum[
-    'bump',
-    'client-first',
-    'none',
-    'peek',
-    'peek-and-splice',
-    'server-first',
-    'splice',
-    'stare',
-    'terminate']
-          $action = 'bump',
-  String  $value  = $title,
-  String  $order  = '05',
+  Squid::Action::SslBump $action = 'bump',
+  String                 $value  = $title,
+  String                 $order  = '05',
 ) {
   concat::fragment { "squid_ssl_bump_${action}_${value}":
     target  => $squid::config,

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -36,5 +36,4 @@ define squid::ssl_bump (
     content => template('squid/squid.conf.ssl_bump.erb'),
     order   => "25-${order}-${action}",
   }
-
 }

--- a/manifests/ssl_bump.pp
+++ b/manifests/ssl_bump.pp
@@ -31,8 +31,7 @@ define squid::ssl_bump (
   String  $value  = $title,
   String  $order  = '05',
 ) {
-
-  concat::fragment{"squid_ssl_bump_${action}_${value}":
+  concat::fragment{ "squid_ssl_bump_${action}_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.ssl_bump.erb'),
     order   => "25-${order}-${action}",

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -23,8 +23,7 @@ define squid::sslproxy_cert_error (
   String  $value  = $title,
   String  $order  = '05',
 ) {
-
-  concat::fragment{"squid_sslproxy_cert_error_${action}_${value}":
+  concat::fragment{ "squid_sslproxy_cert_error_${action}_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.sslproxy_cert_error.erb'),
     order   => "35-${order}-${action}",

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -1,27 +1,26 @@
-# @summary 
+# @summary
 #   Defines sslproxy_cert_error entries for a squid server.
 # @see
-#   http://www.squid-cache.org/Doc/config/sslproxy_cert_error/ 
+#   http://www.squid-cache.org/Doc/config/sslproxy_cert_error/
 # @example
 #   squid::sslproxy_cert_error { 'all':
 #     action => 'allow',
 #   }
-# 
+#
 #   Adds a squid.conf line
 #   sslproxy_cert_error allow all
-# 
-# @param value 
+#
+# @param value
 #   Defaults to the `namevar` the rule to allow or deny.
-# @param action 
+# @param action
 #   Must be `deny` or `allow`. By default it is allow. The squid.conf file is ordered so by default
 #   all allows appear before all denys. This can be overidden with the `order` parameter.
 # @param order
 #   Order can be used to configure where in `squid.conf`this configuration section should occur.
 define squid::sslproxy_cert_error (
-  Enum['allow', 'deny']
-          $action = 'allow',
-  String  $value  = $title,
-  String  $order  = '05',
+  Enum['allow', 'deny'] $action = 'allow',
+  String $value = $title,
+  String $order = '05',
 ) {
   concat::fragment { "squid_sslproxy_cert_error_${action}_${value}":
     target  => $squid::config,

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -28,5 +28,4 @@ define squid::sslproxy_cert_error (
     content => template('squid/squid.conf.sslproxy_cert_error.erb'),
     order   => "35-${order}-${action}",
   }
-
 }

--- a/manifests/sslproxy_cert_error.pp
+++ b/manifests/sslproxy_cert_error.pp
@@ -23,7 +23,7 @@ define squid::sslproxy_cert_error (
   String  $value  = $title,
   String  $order  = '05',
 ) {
-  concat::fragment{ "squid_sslproxy_cert_error_${action}_${value}":
+  concat::fragment { "squid_sslproxy_cert_error_${action}_${value}":
     target  => $squid::config,
     content => template('squid/squid.conf.sslproxy_cert_error.erb'),
     order   => "35-${order}-${action}",

--- a/types/action/sslbump.pp
+++ b/types/action/sslbump.pp
@@ -1,0 +1,11 @@
+type Squid::Action::SslBump = Enum[
+  'bump',
+  'client-first',
+  'none',
+  'peek',
+  'peek-and-splice',
+  'server-first',
+  'splice',
+  'stare',
+  'terminate',
+]


### PR DESCRIPTION
Supercedes #150 and some of #149 
I've split this into several commits.  For `strict_indent` I manually made changes as the autofix results are very poor.