### PR TITLE
Drop EL6 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -59,7 +58,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -67,7 +65,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -75,7 +72,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
The acceptance tests on EL6 are failing and CentOS 6 is soon EOL.

Part of https://github.com/voxpupuli/puppet-squid/pull/158 but here for the separate changelog entry.