### PR TITLE
Allow up-to-date dependencies

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -161,7 +161,7 @@ class squid (
   Optional[String]  $url_rewrite_program           = $squid::params::url_rewrite_program,
   Optional[Integer] $url_rewrite_children          = $squid::params::url_rewrite_children,
   Optional[String]  $url_rewrite_child_options     = $squid::params::url_rewrite_child_options,
-  Optional[Hash]    $extra_config_sections         = {},
+  Hash              $extra_config_sections         = {},
   Optional[Hash]    $http_access                   = $squid::params::http_access,
   Optional[Hash]    $send_hit                      = $squid::params::send_hit,
   Optional[Hash]    $snmp_access                   = $squid::params::snmp_access,

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.25.0 < 7.0.0"
+      "version_requirement": ">= 4.25.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">= 1.2.5 < 7.0.0"
+      "version_requirement": ">= 1.2.5 < 8.0.0"
     },
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
Blocked by:

* https://github.com/voxpupuli/puppet-selinux/pull/348