### PR TITLE
Allow multiple logformat directives in squid.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Parameters to the squid class almost map 1 to 1 to squid.conf parameters themsel
 * `http_ports` defaults to undef. If you pass in a hash of http_port entries, they will be defined automatically. [http_port entries](http://www.squid-cache.org/Doc/config/http_port/).
 * `https_ports` defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. [https_port entries](http://www.squid-cache.org/Doc/config/https_port/).
 * `icp_access` defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. [icp_access entries](http://www.squid-cache.org/Doc/config/icp_access/).
+* `logformat` defaults to undef. If you pass in a String (or Array of Strings), they will be defined automatically. [logformat entries](http://www.squid-cache.org/Doc/config/logformat/).
 * `refresh_patterns` defaults to undef.  If you pass a hash of refresh_pattern entires, they will be defined automatically. [refresh_pattern entries](http://www.squid-cache.org/Doc/config/refresh_pattern/).
 * `snmp_ports` defaults to undef. If you pass in a hash of snmp_port entries, they will be defined automatically. [snmp_port entries](http://www.squid-cache.org/Doc/config/snmp_port/).
 * `send_hit` defaults to undef. If you pass in a hash of send_hit entries, they will be defined automatically. [send_hit entries](http://www.squid-cache.org/Doc/config/send_hit/).

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,8 @@
 #   Defaults to undef. If you pass in a hash of https_port entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/https_port/
 # @param icp_access
 #   Defaults to undef. If you pass in a hash of icp_access entries, they will be defined automatically. http://www.squid-cache.org/Doc/config/icp_access/
+# @param logformat
+#   Defaults to undef. If you pass in a logformat String, it will be defined automatically. May be passed an Array. http://www.squid-cache.org/Doc/config/logformat/
 # @param refresh_patterns
 #   Defaults to undef.  If you pass a hash of refresh_pattern entires, they will be defined automatically. http://www.squid-cache.org/Doc/config/refresh_pattern/
 # @param snmp_ports
@@ -168,7 +170,7 @@ class squid (
   Optional[Hash]    $http_ports                    = $squid::params::http_ports,
   Optional[Hash]    $https_ports                   = $squid::params::https_ports,
   Optional[Hash]    $icp_access                    = $squid::params::icp_access,
-  Optional[String]  $logformat                     = $squid::params::logformat,
+  Optional[Variant[String, Array[String]]] $logformat = $squid::params::logformat,
   Optional[Boolean] $buffered_logs                 = $squid::params::buffered_logs,
   Optional[Integer] $max_filedescriptors           = $squid::params::max_filedescriptors,
   Optional[Variant[Enum['on', 'off'], Boolean]] $memory_cache_shared = $squid::params::memory_cache_shared,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -86,6 +86,18 @@ describe 'squid' do
         it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^url_rewrite_children\s+16\stestoption=a$}) }
       end
 
+      context 'with logformat parameter set to an array' do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        let :params do
+          {
+            config: '/tmp/squid.conf',
+            logformat: ['squid_test_1 %ts.%03tu %6tr', 'squid_test_2 %ts.%03tu duration=%tr']
+          }
+        end
+
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^logformat\s+squid_test_1 %ts.%03tu %6tr$}) }
+        it { is_expected.to contain_concat_fragment('squid_header').with_content(%r{^logformat\s+squid_test_2 %ts.%03tu duration=%tr$}) }
+      end
+
       context 'with access_log parameter set to an array' do # rubocop:todo RSpec/MultipleMemoizedHelpers
         let :params do
           {

--- a/templates/squid.conf.header.erb
+++ b/templates/squid.conf.header.erb
@@ -18,7 +18,9 @@ memory_replacement_policy     <%= @memory_replacement_policy %>
 <% end -%>
 
 <% if @logformat -%>
-logformat                     <%= @logformat %>
+  <%- [@logformat].flatten.each do |logformat_line| -%>
+logformat                     <%= logformat_line %>
+  <%- end -%>
 <% end -%>
 <% unless @buffered_logs.nil? -%>
 buffered_logs                 <%= @buffered_logs?'on':'off' %>


### PR DESCRIPTION
#### Pull Request (PR) description
Similar to #151, this allows the `logformat`parameter to be a String (same as today) or an Array[String], to provide multiple `logformat` directives to squid.

#### This Pull Request (PR) fixes the following issues
n/a