### PR TITLE
Avoid Type=notify for squid service in github CI

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,4 @@
 ---
+# unmanaged as installing puppet-systemd
 spec/spec_helper_acceptance.rb:
-  unmanaged: false
+  unmanaged: true

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,7 +1,36 @@
 require 'spec_helper_acceptance'
 
 describe 'squid class' do
-  context 'configure http_access' do
+  context 'configure http_access with default service type' do
+    it 'works idempotently with no errors' do
+      pending('the default Type=notify in squid.service working again on CentOS 8') if fact('os.family') == 'RedHat' && fact('os.release.major') != '7'
+      pp = <<-EOS
+      # The default Type=notify is problematic in github CI.
+      if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] != '7' {
+        systemd::dropin_file{'simple.conf':
+          ensure => absent,
+          unit   => 'squid.service',
+          before => Service['squid'],
+        }
+      }
+      class { 'squid':}
+      squid::http_port{'3128':}
+      squid::acl{'our_networks':
+        type    => src,
+        entries => ['all'],
+      }
+      squid::http_access{'our_networks':
+        action    => 'allow',
+        comment   => 'Our networks hosts are allowed',
+      }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+
+  context 'configure http_access with simple service type' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
       # The default Type=notify is problematic in github CI.

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -4,6 +4,15 @@ describe 'squid class' do
   context 'configure http_access' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
+      # The default Type=notify is problematic in github CI.
+      if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] != '7' {
+        systemd::dropin_file{'simple.conf':
+          ensure  => present,
+          unit    => 'squid.service',
+          content => "[Service]\nType=simple\n",
+          before  => Service['squid'],
+        }
+      }
       class { 'squid':}
       squid::http_port{'3128':}
       squid::acl{'our_networks':

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,8 +1,9 @@
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-configure_beaker
+configure_beaker do |host|
+  if fact('os.family') == 'RedHat' && fact('os.release.major') != '7'
+    on host, puppet('module', 'install', 'puppet-systemd'), acceptable_exit_codes: [0, 1]
+  end
+end
 
 Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
#### Pull Request (PR) description
squid is failing to start on CentOS 8 acceptance tests with a timeout.

Avoid Type=notify for squid service as it seems the notification never gets there within Gitlab CI even if the service does start.
