### PR TITLE
Moving access_log addition below acls in squid.conf

### DIFF
--- a/manifests/access_log.pp
+++ b/manifests/access_log.pp
@@ -1,0 +1,41 @@
+# @summary
+#   Defines access_log entries for a squid server.
+# @see
+#   http://www.squid-cache.org/Doc/config/access_log/
+# @example
+#   squid::access_log: { 'myAccessLog' :
+#      module    => 'syslog'
+#      entries => [
+#        'place daemon'
+#        'logformat squid'
+#        'acl hasRequest'
+#     ],
+# }
+#
+#   Adds a squid.conf line:
+#   squid::access_log: syslog:daemon squid hasRequest
+# @param module
+#   Location of access log
+# @param entries
+#   Access log entry's preceding comment
+# @param order
+#   Order can be used to configure where in `squid.conf`this configuration section should occur.
+define squid::access_log (
+  Enum['none', 'stdio', 'daemon', 'syslog', 'udp', 'tcp'] $module,
+  Variant[String, Array[String]] $entries,
+  String $access_log_name = $title,
+  String $order           = '50',
+) {
+  $entries_array = $entries ? {
+    String  => [$entries],
+    default => $entries,
+  }
+
+  $entries_array.each |$entry| {
+    concat::fragment { "squid_access_log_${access_log_name}_${entry}":
+      target  => $squid::config,
+      content => epp('squid/squid.conf.access_log.epp', { 'module' => $module, 'entry' => $entry }),
+      order   => "38-${order}-${module}",
+    }
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,6 +61,28 @@ class squid::config (
   if $acls {
     create_resources('squid::acl', $acls)
   }
+  if $access_log {
+    if $access_log =~ Hash {
+      # Use create_resources if $access_log is a hash
+      create_resources('squid::access_log', $access_log)
+    } elsif $access_log =~ Array {
+      # Use a loop to iterate over the $access_log array if it's an array
+      $access_log.each |$log| {
+        squid::access_log { $log['module']:
+          entries => $log['entries'],
+        }
+      }
+    } elsif $access_log =~ String {
+      # Use regsubst to extract the module and the remaining entries
+      $module = regsubst($access_log, '^(\w+):(.*)$', '\1')
+      $entries = regsubst($access_log, '^(\w+):(.*)$', '\2')  
+      # Create a single access_log resource using the extracted module and entries
+      squid::access_log { $module:
+        module  => $module,
+        entries => $entries,
+      }
+    }
+  }
   if $http_access {
     create_resources('squid::http_access', $http_access)
   }

--- a/templates/squid.conf.access_log.epp
+++ b/templates/squid.conf.access_log.epp
@@ -1,0 +1,2 @@
+# access_log fragment for <%= $module %>
+access_log <%= $module %> <%= $entry %>

--- a/templates/squid.conf.header.erb
+++ b/templates/squid.conf.header.erb
@@ -25,13 +25,6 @@ logformat                     <%= logformat_line %>
 <% unless @buffered_logs.nil? -%>
 buffered_logs                 <%= @buffered_logs?'on':'off' %>
 <% end -%>
-<% if @access_log.is_a?(Array) %>
-<% @access_log.each do |access_log_line| -%>
-access_log                    <%= access_log_line %>
-<% end -%>
-<% else -%>
-access_log                    <%= @access_log %>
-<% end -%>
 
 <% if @coredump_dir -%>
 coredump_dir                  <%= @coredump_dir %>


### PR DESCRIPTION
In order to use acls as a param for the access_log module, access_logs must be created **after** the acls. This can't happen as long as access_logs are defined in the header which is always added to squid.conf before other params
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
