### PR TITLE
fix unexpected double space after refresh_pattern word

### DIFF
--- a/templates/squid.conf.refresh_pattern.epp
+++ b/templates/squid.conf.refresh_pattern.epp
@@ -8,4 +8,4 @@
   Optional[String[1]] $options,
 | -%>
 # <%= $comment %>
-refresh_pattern <% unless $case_sensitive { %> -i <% } %><%= $pattern %> <%= $min %> <%= $percent %>% <%= $max %><% if $options { %> <%= $options %><% } %>
+refresh_pattern <% unless $case_sensitive { %>-i <% } %><%= $pattern %> <%= $min %> <%= $percent %>% <%= $max %><% if $options { %> <%= $options %><% } %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
In the current state, `refresh_pattern` line is generated with double empty spaces between the param word `refresh_pattern` and the first arg (`-i`):

```
refresh_pattern  -i
               ^^
```

This PR just remove one space char.
