### PR TITLE
http_port: Add support for IPv6 addresses

### DIFF
--- a/manifests/http_port.pp
+++ b/manifests/http_port.pp
@@ -61,10 +61,10 @@ define squid::http_port (
     fail('port parameter was not specified and could not be determined from title')
   }
 
-  if $_host != undef {
-    $_host_port = "${_host}:${_port}"
-  } else {
-    $_host_port = String($_port)
+  $_host_port = $_host ? {
+    undef                   => String($_port),
+    Stdlib::IP::Address::V6 => "[${_host}]:${_port}",
+    default                 => "${_host}:${_port}",
   }
 
   $protocol = $ssl ? {

--- a/spec/defines/http_port_spec.rb
+++ b/spec/defines/http_port_spec.rb
@@ -71,6 +71,19 @@ describe 'squid::http_port' do
         it { is_expected.to contain_concat_fragment('squid_http_port_host:1650').with_content(%r{^http_port\s+1650$}) }
       end
 
+      context 'with IPv6' do
+        let(:title) { 'ipv6_host' }
+        let(:params) do
+          {
+            host: "2001:db8::1",
+            port: 1650,
+          }
+        end
+
+        # Wrap IPv6addresses in square brackets
+        it { is_expected.to contain_concat_fragment('squid_http_port_ipv6_host').with_content(%r{^http_port\s+\[2001:db8::1\]:1650$}) }
+      end
+
       context 'without a port specified' do
         let(:title) { 'garbage' }
         let(:params) do


### PR DESCRIPTION
When using an ipv6 address in the host we need to wrap the addresses win square brackets.

