### PR TITLE
fix(extra_config_section): Use title in titles and ordering parameters for concat

### DIFF
--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -1,6 +1,6 @@
 # @summary 
-#   The `extra_config_section` defiend type can be used for configuration directives that have not been exposed individually in this module.
-# 
+#   The `extra_config_section` defined type can be used for configuration directives that have not been exposed individually in this module.
+#
 # @example Using a hash of config_entries:
 #   squid::extra_config_section { 'mail settings':
 #     order          => '60',
@@ -9,12 +9,12 @@
 #       'mail_program' => 'mail',
 #     },
 #   }
-# 
+#
 #   Results in a squid configuration of
 #   # mail settings
 #   mail_from squid@example.com
 #   mail_program mail
-# 
+#
 # @example Using an array of config_entries:
 #   squid::extra_config_section { 'ssl_bump settings':
 #     order          => '60',
@@ -24,13 +24,13 @@
 #       'sslcrtd_children' => ['8', 'startup=1', 'idle=1'],
 #     }
 #   }
-# 
+#
 #   Results in a squid configuration of:
 #   # ssl_bump settings
 #   ssl_bump server-first all
 #   sslcrtd_program /usr/lib64/squid/ssl_crtd -s /var/lib/ssl_db -M 4MB
 #   sslcrtd_children 8 startup=1 idle=1
-# 
+#
 # @example Using an array of hashes of config_entries:
 #   squid::extra_config_section { 'always_directs':
 #     order          => '60',
@@ -40,19 +40,19 @@
 #                           'allow   my-other-good-dst'],
 #     }],
 #   }
-# 
+#
 #   Results in a squid configuration of
 #   # always_directs
 #   always_direct deny    www.reallyreallybadplace.com
 #   always_direct allow   my-good-dst
 #   always_direct allow   my-other-good-dst
-# 
-# @param comment 
+#
+# @param comment
 #   Defaults to the namevar and is used as a section comment in `squid.conf`.
-# @param config_entries 
-#   A hash of configuration entries to create in this section.  The hash key is the name of the configuration directive.  
+# @param config_entries
+#   A hash of configuration entries to create in this section.  The hash key is the name of the configuration directive.
 #   The value is either a string, or an array of strings to use as the configuration directive options.
-# @param order 
+# @param order
 #   Order can be used to configure where in `squid.conf` this configuration section should occur.
 define squid::extra_config_section (
   String              $comment = $title,

--- a/manifests/extra_config_section.pp
+++ b/manifests/extra_config_section.pp
@@ -59,9 +59,9 @@ define squid::extra_config_section (
   Variant[Array,Hash] $config_entries = {},
   String              $order   = '60',
 ) {
-  concat::fragment { "squid_extra_config_section_${comment}":
+  concat::fragment { "squid_extra_config_section_${title}":
     target  => $squid::config,
     content => template('squid/squid.conf.extra_config_section.erb'),
-    order   => "${order}-${comment}",
+    order   => "${order}-${title}",
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
By using comment in the title and ordering, we are unable to use special characters in the comments. While pretty much anything should be allowed.
